### PR TITLE
１枚完結のHTMLレポート対応

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -444,6 +444,25 @@ function ReportCard({
                 </Portal>
               </Popover.Root>
             )}
+            {/* ✅ 軽量HTMLレポートボタン（常設） */}
+            {report.status === "ready" && (
+              <Button
+                variant="ghost"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(`${getApiBaseUrl()}/admin/reports/${report.slug}/simple-html`, "_blank");
+                }}
+              >
+                <Tooltip content="１枚完結のHTMLレポートを表示" openDelay={0} closeDelay={0}>
+                  <Flex align="center" gap={1}>
+                    <Icon>
+                      <ExternalLinkIcon />
+                    </Icon>
+                    <Text fontSize="sm">シンプル版</Text>
+                  </Flex>
+                </Tooltip>
+              </Button>
+            )}
             {report.status === "ready" && (
               <Box
                 onClick={(e) => e.stopPropagation()}

--- a/server/broadlistening/pipeline/hierarchical_main.py
+++ b/server/broadlistening/pipeline/hierarchical_main.py
@@ -4,6 +4,7 @@ import sys
 from hierarchical_utils import initialization, run_step, termination
 from steps.embedding import embedding
 from steps.extraction import extraction
+from steps.generate_simple_html import generate_simple_html
 from steps.hierarchical_aggregation import hierarchical_aggregation
 from steps.hierarchical_clustering import hierarchical_clustering
 from steps.hierarchical_initial_labelling import hierarchical_initial_labelling
@@ -65,6 +66,11 @@ def main():
         run_step("hierarchical_merge_labelling", hierarchical_merge_labelling, config)
         run_step("hierarchical_overview", hierarchical_overview, config)
         run_step("hierarchical_aggregation", hierarchical_aggregation, config)
+        try:
+            print("[INFO] Generating simple HTML report...")
+            generate_simple_html(config)
+        except Exception as e:
+            print(f"[WARN] Failed to generate simple HTML report: {e}")
         run_step("hierarchical_visualization", hierarchical_visualization, config)
 
         termination(config)

--- a/server/broadlistening/pipeline/steps/generate_simple_html.py
+++ b/server/broadlistening/pipeline/steps/generate_simple_html.py
@@ -1,0 +1,90 @@
+import colorsys
+import json
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def load_json_with_fallback(path: Path):
+    """UTF-8優先 → SJISフォールバックでJSON読み込み"""
+    if not path.exists():
+        print(f"⚠️ Missing: {path}")
+        return {}
+    try:
+        with open(path, encoding='utf-8') as f:
+            return json.load(f)
+    except UnicodeDecodeError:
+        with open(path, encoding='shift_jis') as f:
+            return json.load(f)
+
+
+def generate_simple_html(config):
+    output_dir = config["output_dir"]
+    base_path = Path(f"outputs/{output_dir}")
+    input_path = base_path / "hierarchical_result.json"
+    output_path = base_path / "simple_report.html"
+    overview_path = base_path / "hierarchical_overview.txt"
+    template_dir = Path("templates")
+    template_name = "simple_report_template.html"
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"⛔ {input_path} が見つかりません")
+
+    result = load_json_with_fallback(input_path)
+    hierarchical_overview = overview_path.read_text(encoding="utf-8") if overview_path.exists() else ""
+
+    # クラスタ構造を再構築
+    clusters = result["clusters"]
+    cluster_by_id = {c["id"]: c for c in clusters}
+    cluster_children = {}
+    for c in clusters:
+        parent = c.get("parent")
+        if parent:
+            cluster_children.setdefault(parent, []).append(c)
+
+    def build_tree(cluster):
+        cid = cluster["id"]
+        cluster["children"] = [build_tree(child) for child in cluster_children.get(cid, [])]
+        return cluster
+
+    # 上位層クラスタのみ対象
+    level1_clusters = [c for c in clusters if c.get("level") == 1]
+    cluster_tree = [build_tree(c) for c in level1_clusters]
+
+    # 色マップ（Lv1クラスタのみ）
+    color_map = {}
+    for i, c in enumerate(level1_clusters):
+        hue = (i * 0.14) % 1.0
+        rgb = colorsys.hsv_to_rgb(hue, 0.6, 0.7)
+        hex_color = '#{:02x}{:02x}{:02x}'.format(int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
+        color_map[c["id"]] = hex_color
+
+    # 上位クラスタごとに属する arguments を収集（Lv2経由でない）
+    cluster_args_map = {}
+    for c in level1_clusters:
+        cluster_args_map[c["id"]] = [
+            a for a in result["arguments"]
+            if c["id"] in a.get("cluster_ids", [])
+        ]
+
+    env = Environment(loader=FileSystemLoader(str(template_dir)))
+    env.tests["search"] = lambda value, sub: sub in value
+    template = env.get_template(template_name)
+
+    html = template.render(
+        result=result,
+        cluster_tree=cluster_tree,
+        hierarchical_overview=hierarchical_overview,
+        color_map=color_map,
+        cluster_args_map=cluster_args_map  # JavaScriptで活用する場合にも利用可能
+    )
+    output_path.write_text(html, encoding="utf-8")
+    print(f"✅ 出力完了: {output_path}")
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 2:
+        print("Usage: python generate_simple_html.py [dataset-slug]")
+        sys.exit(1)
+    generate_simple_html({"output_dir": sys.argv[1]})

--- a/server/broadlistening/pipeline/steps/generate_simple_html.py
+++ b/server/broadlistening/pipeline/steps/generate_simple_html.py
@@ -35,7 +35,6 @@ def generate_simple_html(config):
 
     # クラスタ構造を再構築
     clusters = result["clusters"]
-    cluster_by_id = {c["id"]: c for c in clusters}
     cluster_children = {}
     for c in clusters:
         parent = c.get("parent")
@@ -56,7 +55,7 @@ def generate_simple_html(config):
     for i, c in enumerate(level1_clusters):
         hue = (i * 0.14) % 1.0
         rgb = colorsys.hsv_to_rgb(hue, 0.6, 0.7)
-        hex_color = '#{:02x}{:02x}{:02x}'.format(int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
+        hex_color = f'#{int(rgb[0] * 255):02x}{int(rgb[1] * 255):02x}{int(rgb[2] * 255):02x}'
         color_map[c["id"]] = hex_color
 
     # 上位クラスタごとに属する arguments を収集（Lv2経由でない）

--- a/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
@@ -91,8 +91,11 @@ def create_custom_intro(config):
     print(f"Input count: {input_count}")
     print(f"Args count: {args_count}")
 
+#    base_custom_intro = """{intro}
+#分析対象となったデータの件数は{processed_num}件で、これらのデータに対してOpenAI APIを用いて{args_count}件の意見（議論）を抽出し、クラスタリングを行った。
+#"""
     base_custom_intro = """{intro}
-分析対象となったデータの件数は{processed_num}件で、これらのデータに対してOpenAI APIを用いて{args_count}件の意見（議論）を抽出し、クラスタリングを行った。
+分析対象となったデータは{processed_num}件で、LLM（大規模言語モデル）を用いて{args_count}件の意見（議論）を抽出し、それらを意見グループに分類した。
 """
 
     intro = config["intro"]

--- a/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
@@ -3,12 +3,40 @@
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, TypedDict
 
+import numpy as np
 import pandas as pd
 
 ROOT_DIR = Path(__file__).parent.parent.parent.parent
 CONFIG_DIR = ROOT_DIR / "scatter" / "pipeline" / "configs"
+PIPELINE_DIR = ROOT_DIR / "broadlistening" / "pipeline"
+
+
+def json_serialize_numpy(obj: Any) -> Any:
+    """
+    Recursively convert NumPy data types to native Python types for JSON serialization.
+
+    Args:
+        obj: Any Python object which might contain NumPy data types
+
+    Returns:
+        The same object structure with NumPy types converted to Python native types
+    """
+    if isinstance(obj, np.integer):
+        return int(obj)
+    elif isinstance(obj, np.floating):
+        return float(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
+    elif isinstance(obj, dict):
+        return {k: json_serialize_numpy(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [json_serialize_numpy(item) for item in obj]
+    elif isinstance(obj, tuple):
+        return tuple(json_serialize_numpy(item) for item in obj)
+    else:
+        return obj
 
 
 class Argument(TypedDict):
@@ -19,6 +47,8 @@ class Argument(TypedDict):
     y: float
     p: float
     cluster_ids: list[str]
+    attributes: dict[str, str] | None
+    url: str | None
 
 
 class Cluster(TypedDict):
@@ -31,58 +61,67 @@ class Cluster(TypedDict):
     density_rank_percentile: float | None
 
 
-def hierarchical_aggregation(config):
-    path = f"outputs/{config['output_dir']}/hierarchical_result.json"
-    results = {
-        "arguments": [],
-        "clusters": [],
-        "comments": {},
-        "propertyMap": {},
-        "translations": {},
-        "overview": "",
-        "config": config,
-    }
+def hierarchical_aggregation(config) -> bool:
+    try:
+        path = f"outputs/{config['output_dir']}/hierarchical_result.json"
+        results = {
+            "arguments": [],
+            "clusters": [],
+            "comments": {},
+            "propertyMap": {},
+            "translations": {},
+            "overview": "",
+            "config": config,
+        }
 
-    arguments = pd.read_csv(f"outputs/{config['output_dir']}/args.csv")
-    arguments.set_index("arg-id", inplace=True)
-    arg_num = len(arguments)
-    relation_df = pd.read_csv(f"outputs/{config['output_dir']}/relations.csv")
-    comments = pd.read_csv(f"inputs/{config['input']}.csv")
-    clusters = pd.read_csv(f"outputs/{config['output_dir']}/hierarchical_clusters.csv")
-    labels = pd.read_csv(f"outputs/{config['output_dir']}/hierarchical_merge_labels.csv")
+        arguments = pd.read_csv(f"outputs/{config['output_dir']}/args.csv")
+        arguments.set_index("arg-id", inplace=True)
+        arg_num = len(arguments)
+        relation_df = pd.read_csv(f"outputs/{config['output_dir']}/relations.csv")
+        comments = pd.read_csv(f"inputs/{config['input']}.csv")
+        clusters = pd.read_csv(f"outputs/{config['output_dir']}/hierarchical_clusters.csv")
+        labels = pd.read_csv(f"outputs/{config['output_dir']}/hierarchical_merge_labels.csv")
 
-    hidden_properties_map: dict[str, list[str]] = config["hierarchical_aggregation"]["hidden_properties"]
+        hidden_properties_map: dict[str, list[str]] = config["hierarchical_aggregation"]["hidden_properties"]
 
-    results["arguments"] = _build_arguments(clusters)
-    results["clusters"] = _build_cluster_value(labels, arg_num)
-    # NOTE: 属性に応じたコメントフィルタ機能が実装されておらず、全てのコメントが含まれてしまうので、コメントアウト
-    # results["comments"] = _build_comments_value(
-    #     comments, arguments, hidden_properties_map
-    # )
-    results["comment_num"] = len(comments)
-    results["translations"] = _build_translations(config)
-    # 属性情報のカラムは、元データに対して指定したカラムとclassificationするカテゴリを合わせたもの
-    results["propertyMap"] = _build_property_map(arguments, hidden_properties_map, config)
+        results["arguments"] = _build_arguments(clusters, comments, relation_df, config)
+        results["clusters"] = _build_cluster_value(labels, arg_num)
 
-    with open(f"outputs/{config['output_dir']}/hierarchical_overview.txt") as f:
-        overview = f.read()
-    print("overview")
-    print(overview)
-    results["overview"] = overview
+        # results["comments"] = _build_comments_value(
+        #     comments, arguments, hidden_properties_map
+        # )
+        results["comment_num"] = len(comments)
+        results["translations"] = _build_translations(config)
+        # 属性情報のカラムは、元データに対して指定したカラムとclassificationするカテゴリを合わせたもの
+        results["propertyMap"] = _build_property_map(arguments, comments, hidden_properties_map, config)
 
-    with open(path, "w") as file:
-        json.dump(results, file, indent=2, ensure_ascii=False)
-    # TODO: サンプリングロジックを実装したいが、現状は全件抽出
-    create_custom_intro(config)
-    if config["is_pubcom"]:
-        add_original_comments(labels, arguments, relation_df, clusters, config)
+        with open(f"outputs/{config['output_dir']}/hierarchical_overview.txt") as f:
+            overview = f.read()
+        print("overview")
+        print(overview)
+        results["overview"] = overview
+
+        # Convert non-serializable NumPy types to native Python types
+        results = json_serialize_numpy(results)
+
+        with open(path, "w") as file:
+            json.dump(results, file, indent=2, ensure_ascii=False)
+        # TODO: サンプリングロジックを実装したいが、現状は全件抽出
+        create_custom_intro(config)
+        if config["is_pubcom"]:
+            add_original_comments(labels, arguments, relation_df, clusters, config)
+        return True
+    except Exception as e:
+        print("error")
+        print(e)
+        return False
 
 
 def create_custom_intro(config):
     dataset = config["output_dir"]
-    args_path = f"outputs/{dataset}/args.csv"
-    comments = pd.read_csv(f"inputs/{config['input']}.csv")
-    result_path = f"outputs/{dataset}/hierarchical_result.json"
+    args_path = PIPELINE_DIR / f"outputs/{dataset}/args.csv"
+    comments = pd.read_csv(PIPELINE_DIR / f"inputs/{config['input']}.csv")
+    result_path = PIPELINE_DIR / f"outputs/{dataset}/hierarchical_result.json"
 
     input_count = len(comments)
     args_count = len(pd.read_csv(args_path))
@@ -91,11 +130,8 @@ def create_custom_intro(config):
     print(f"Input count: {input_count}")
     print(f"Args count: {args_count}")
 
-#    base_custom_intro = """{intro}
-#分析対象となったデータの件数は{processed_num}件で、これらのデータに対してOpenAI APIを用いて{args_count}件の意見（議論）を抽出し、クラスタリングを行った。
-#"""
     base_custom_intro = """{intro}
-分析対象となったデータは{processed_num}件で、LLM（大規模言語モデル）を用いて{args_count}件の意見（議論）を抽出し、それらを意見グループに分類した。
+分析対象となったデータの件数は{processed_num}件で、これらのデータから{args_count}件の意見（議論）を抽出し、グループ化を行った。
 """
 
     intro = config["intro"]
@@ -123,7 +159,7 @@ def add_original_comments(labels, arguments, relation_df, clusters, config):
     merged = merged.merge(relation_df, on="arg-id", how="left")
 
     # 元コメント取得
-    comments = pd.read_csv(f"inputs/{config['input']}.csv")
+    comments = pd.read_csv(PIPELINE_DIR / f"inputs/{config['input']}.csv")
     comments["comment-id"] = comments["comment-id"].astype(str)
     merged["comment-id"] = merged["comment-id"].astype(str)
 
@@ -132,10 +168,23 @@ def add_original_comments(labels, arguments, relation_df, clusters, config):
 
     # 必要カラムのみ整形
     final_cols = ["comment-id", "comment-body", "arg-id", "argument", "cluster-level-1-id", "category_label"]
-    for col in ["source", "url"]:
+
+    # 基本カラム
+    for col in ["x", "y", "source", "url"]:
         if col in comments.columns:
             final_cols.append(col)
 
+    # 属性カラムを追加
+    attribute_columns = []
+    for col in comments.columns:
+        # attributeプレフィックスが付いたカラムを探す
+        if col.startswith("attribute_"):
+            attribute_columns.append(col)
+            final_cols.append(col)
+
+    print(f"属性カラム検出: {attribute_columns}")
+
+    # 必要なカラムだけ選択
     final_df = final_df[final_cols]
     final_df = final_df.rename(
         columns={
@@ -148,25 +197,88 @@ def add_original_comments(labels, arguments, relation_df, clusters, config):
     )
 
     # 保存
-    final_df.to_csv(f"outputs/{config['output_dir']}/final_result_with_comments.csv", index=False)
+    final_df.to_csv(PIPELINE_DIR / f"outputs/{config['output_dir']}/final_result_with_comments.csv", index=False)
 
 
-def _build_arguments(clusters: pd.DataFrame) -> list[Argument]:
+def _build_arguments(
+    clusters: pd.DataFrame, comments: pd.DataFrame, relation_df: pd.DataFrame, config: dict
+) -> list[Argument]:
+    """
+    Build the arguments list including attribute information from original comments
+
+    Args:
+        clusters: DataFrame containing cluster information for each argument
+        comments: DataFrame containing original comments with attribute columns
+        relation_df: DataFrame relating arguments to original comments
+        config: Configuration dictionary containing enable_source_link setting
+    """
     cluster_columns = [col for col in clusters.columns if col.startswith("cluster-level-") and "id" in col]
+
+    # Prepare for merging with original comments to get attributes
+    comments_copy = comments.copy()
+    comments_copy["comment-id"] = comments_copy["comment-id"].astype(str)
+
+    # Get argument to comment mapping
+    arg_comment_map = {}
+    if "comment-id" in relation_df.columns:
+        relation_df["comment-id"] = relation_df["comment-id"].astype(str)
+        arg_comment_map = dict(zip(relation_df["arg-id"], relation_df["comment-id"], strict=False))
+
+    # Find attribute columns in comments dataframe
+    attribute_columns = [col for col in comments.columns if col.startswith("attribute_")]
+    print(f"属性カラム検出: {attribute_columns}")
 
     arguments: list[Argument] = []
     for _, row in clusters.iterrows():
         cluster_ids = ["0"]
         for cluster_column in cluster_columns:
-            cluster_ids.append(row[cluster_column])
+            cluster_ids.append(str(row[cluster_column]))  # Convert to string to ensure serializable
+
+        # Create base argument
         argument: Argument = {
-            "arg_id": row["arg-id"],
-            "argument": row["argument"],
-            "x": row["x"],
-            "y": row["y"],
+            "arg_id": str(row["arg-id"]),  # Convert to string to ensure serializable
+            "argument": str(row["argument"]),
+            "x": float(row["x"]),  # Convert to native float
+            "y": float(row["y"]),  # Convert to native float
             "p": 0,  # NOTE: 一旦全部0でいれる
             "cluster_ids": cluster_ids,
+            "attributes": None,
+            "url": None,
         }
+
+        # Add attributes and URL if available
+        if row["arg-id"] in arg_comment_map:
+            comment_id = arg_comment_map[row["arg-id"]]
+            comment_rows = comments_copy[comments_copy["comment-id"] == comment_id]
+
+            if not comment_rows.empty:
+                comment_row = comment_rows.iloc[0]
+
+                # Add URL if available and enabled
+                if config.get("enable_source_link", False) and "url" in comment_row and comment_row["url"] is not None:
+                    argument["url"] = str(comment_row["url"])
+
+                # Add attributes if available
+                if attribute_columns:
+                    attributes = {}
+                    for attr_col in attribute_columns:
+                        # Remove "attribute_" prefix for cleaner attribute names
+                        attr_name = attr_col[len("attribute_") :]
+                        # Convert potential numpy types to Python native types
+                        attr_value = comment_row.get(attr_col, None)
+                        if attr_value is not None:
+                            if isinstance(attr_value, np.integer):
+                                attr_value = int(attr_value)
+                            elif isinstance(attr_value, np.floating):
+                                attr_value = float(attr_value)
+                            elif isinstance(attr_value, np.ndarray):
+                                attr_value = attr_value.tolist()
+                        attributes[attr_name] = attr_value
+
+                    # Only add non-empty attributes
+                    if any(v is not None for v in attributes.values()):
+                        argument["attributes"] = attributes
+
         arguments.append(argument)
     return arguments
 
@@ -178,21 +290,41 @@ def _build_cluster_value(melted_labels: pd.DataFrame, total_num: int) -> list[Cl
             id="0",
             label="全体",
             takeaway="",
-            value=total_num,
+            value=int(total_num),  # Convert to native int
             parent="",
             density_rank_percentile=0,
         )
     ]
 
     for _, melted_label in melted_labels.iterrows():
+        # Convert potential NumPy types to native Python types
+        level = (
+            int(melted_label["level"]) if isinstance(melted_label["level"], int | np.integer) else melted_label["level"]
+        )
+        cluster_id = str(melted_label["id"])
+        label = str(melted_label["label"])
+        takeaway = str(melted_label["description"])
+        value = (
+            int(melted_label["value"]) if isinstance(melted_label["value"], int | np.integer) else melted_label["value"]
+        )
+        parent = str(melted_label.get("parent", "全体"))
+
+        # Handle density_rank_percentile which might be None or a numeric value
+        density_rank = melted_label.get("density_rank_percentile")
+        if density_rank is not None:
+            if isinstance(density_rank, float | np.floating):
+                density_rank = float(density_rank)
+            elif isinstance(density_rank, int | np.integer):
+                density_rank = int(density_rank)
+
         cluster_value = Cluster(
-            level=melted_label["level"],
-            id=melted_label["id"],
-            label=melted_label["label"],
-            takeaway=melted_label["description"],
-            value=melted_label["value"],
-            parent=melted_label.get("parent", "全体"),
-            density_rank_percentile=melted_label.get("density_rank_percentile"),
+            level=level,
+            id=cluster_id,
+            label=label,
+            takeaway=takeaway,
+            value=value,
+            parent=parent,
+            density_rank_percentile=density_rank,
         )
         results.append(cluster_value)
     return results
@@ -220,14 +352,14 @@ def _build_comments_value(
 def _build_translations(config):
     languages = list(config.get("translation", {}).get("languages", []))
     if len(languages) > 0:
-        with open(f"outputs/{config['output_dir']}/translations.json") as f:
+        with open(PIPELINE_DIR / f"outputs/{config['output_dir']}/translations.json") as f:
             translations = f.read()
         return json.loads(translations)
     return {}
 
 
 def _build_property_map(
-    arguments: pd.DataFrame, hidden_properties_map: dict[str, list[str]], config: dict
+    arguments: pd.DataFrame, comments: pd.DataFrame, hidden_properties_map: dict[str, list[str]], config: dict
 ) -> dict[str, dict[str, str]]:
     property_columns = list(hidden_properties_map.keys()) + list(config["extraction"]["categories"].keys())
     property_map = defaultdict(dict)
@@ -243,5 +375,26 @@ def _build_property_map(
     for prop in property_columns:
         for arg_id, row in arguments.iterrows():
             # LLMによるcategory classificationがうまく行かず、NaNの場合はNoneにする
-            property_map[prop][arg_id] = row[prop] if not pd.isna(row[prop]) else None
+            value = row[prop] if not pd.isna(row[prop]) else None
+
+            # Convert NumPy types to Python native types
+            if value is not None:
+                if isinstance(value, np.integer):
+                    value = int(value)
+                elif isinstance(value, np.floating):
+                    value = float(value)
+                elif isinstance(value, np.ndarray):
+                    value = value.tolist()
+                else:
+                    # Convert any other types to string to ensure serialization
+                    try:
+                        value = str(value)
+                    except Exception as e:
+                        print(f"Error converting value to string: {e}")
+                        value = None
+
+            # Make sure arg_id is string
+            str_arg_id = str(arg_id)
+            property_map[prop][str_arg_id] = value
+
     return property_map

--- a/server/broadlistening/pipeline/templates/simple_report_template.html
+++ b/server/broadlistening/pipeline/templates/simple_report_template.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>{{ result.config.question }}</title>
+    <script src="https://cdn.plot.ly/plotly-2.26.0.min.js"></script>
+    <style>
+        body {
+            font-family: sans-serif;
+            margin: 20px;
+            max-width: 1200px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        h1 {
+            color: #2577B1;
+        }
+
+        .intro,
+        .overview {
+            margin-bottom: 1em;
+            white-space: pre-wrap;
+        }
+
+        .group {
+            border: 1px solid #ccc;
+            margin: 5px 0;
+            padding: 5px 10px;
+        }
+
+        .group-header {
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background-color: #f7f7f7;
+            padding: 5px;
+        }
+
+        .group-header .toggle {
+            font-weight: bold;
+            margin-right: 10px;
+            user-select: none;
+        }
+
+        .group-header .title {
+            flex: 1;
+        }
+
+        .group-header .stats {
+            font-size: 0.9em;
+            color: #555;
+            margin-left: 10px;
+        }
+
+        .summary {
+            font-size: 0.9em;
+            color: #333;
+            margin-left: 20px;
+        }
+
+        .group-children,
+        .arguments {
+            margin-left: 20px;
+            border-left: 1px dashed #ccc;
+            padding-left: 10px;
+        }
+
+        .argument {
+            margin: 5px 0;
+            padding: 3px;
+            background-color: #eef;
+        }
+
+        #toggleAll,
+        #toggleLabels {
+            margin: 10px 5px 15px 0;
+            background-color: #3182ce;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            padding: 8px 12px;
+            font-size: 1em;
+            cursor: pointer;
+        }
+
+        #toggleAll:hover,
+        #toggleLabels:hover {
+            background-color: #2a69ac;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>{{ result.config.question }}</h1>
+    <div class="overview">{{ hierarchical_overview }}</div>
+
+    <div class="chart-container" id="scatterChart"></div>
+
+    <h2>意見グループ一覧</h2>
+    <button id="toggleAll" onclick="toggleAllGroups()">すべて展開</button>
+    <button id="toggleLabels" onclick="toggleLabels()">ラベル非表示</button>
+    <div id="groupContainer">
+        {% macro render_group(group, parent_color='') %}
+        {%- if group.level == 1 and color_map[group.id] is defined -%}
+        {%- set my_color = color_map[group.id] -%}
+        {%- else -%}
+        {%- set my_color = parent_color -%}
+        {%- endif %}
+
+        <div class="group" data-group-id="{{ group.id }}">
+            <div class="group-header" onclick="toggleThisGroup(this)" style="color: {{ my_color }};">
+                <span class="toggle">[+]</span>
+                <span class="title">{{ group.label }}</span>
+                <span class="stats">{{ group.value }}件</span>
+            </div>
+            <div class="summary">{{ group.takeaway }}</div>
+
+            {% if group.children and group.children | length > 0 %}
+            <div class="group-children" style="display: none;">
+                {% for child in group.children %}
+                {{ render_group(child, my_color) }}
+                {% endfor %}
+            </div>
+            {% else %}
+            {% set group_args = result.arguments | selectattr("cluster_ids", "search", group.id) | list %}
+            {% if group_args | length > 0 %}
+            <div class="arguments" style="display: none;">
+                {% for arg in group_args %}
+                <div class="argument">{{ arg.argument }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% endif %}
+        </div>
+        {% endmacro %}
+
+        {% for group in cluster_tree %}
+        {{ render_group(group) }}
+        {% endfor %}
+
+        <div class="intro">{{ result.config.intro }}</div>
+    </div>
+
+    <script>
+        const result = {{ result | tojson(indent = 2) }};
+        const color_map = {{ color_map | tojson(indent = 2) }};
+        const clusters = result.clusters.filter(c => c.level === 1);
+        const args = result.arguments;
+
+        let labelVisible = true;
+
+        const clusterLabels = clusters.map((cluster, idx) => {
+            const clusterArgs = args.filter(arg => arg.cluster_ids.includes(cluster.id));
+            if (clusterArgs.length === 0) return null;
+            const centerX = clusterArgs.map(arg => arg.x).reduce((a, b) => a + b, 0) / clusterArgs.length;
+            const centerY = clusterArgs.map(arg => arg.y).reduce((a, b) => a + b, 0) / clusterArgs.length;
+            const bgColor = color_map[cluster.id] || `hsl(${(idx * 40) % 360},70%,60%)`;
+            return {
+                x: centerX,
+                y: centerY,
+                text: cluster.label,
+                showarrow: false,
+                font: { size: 13, color: "white" },
+                align: "center",
+                bgcolor: bgColor,
+                opacity: 0.7,
+                borderpad: 4
+            };
+        }).filter(Boolean);
+
+        function toggleLabels() {
+            labelVisible = !labelVisible;
+            const newAnnotations = clusterLabels.map(label => ({ ...label, visible: labelVisible }));
+            Plotly.relayout("scatterChart", { annotations: newAnnotations });
+            const btn = document.getElementById("toggleLabels");
+            btn.textContent = labelVisible ? "ラベル非表示" : "ラベル表示";
+        }
+
+        const scatterData = clusters.map((cluster, idx) => {
+            const clusterArgs = args.filter(arg => arg.cluster_ids.includes(cluster.id));
+            const x = clusterArgs.map(arg => arg.x);
+            const y = clusterArgs.map(arg => arg.y);
+            const color = color_map[cluster.id] || `hsl(${(idx * 40) % 360},70%,60%)`;
+            return {
+                x: x,
+                y: y,
+                mode: "markers",
+                type: "scatter",
+                name: cluster.label,
+                marker: { color: color, size: 7 },
+                text: clusterArgs.map(arg => `<b>${cluster.label}</b><br>${arg.argument.replace(/(.{30})/g, "$1<br>")}`),
+                hoverinfo: "text"
+            };
+        });
+
+        Plotly.newPlot("scatterChart", scatterData, {
+            margin: { l: 20, r: 20, t: 20, b: 20 },
+            xaxis: { showticklabels: false, zeroline: false },
+            yaxis: { showticklabels: false, zeroline: false },
+            hovermode: "closest",
+            showlegend: false,
+            annotations: clusterLabels
+        }, { responsive: true });
+
+        function toggleThisGroup(headerElem) {
+            const groupElem = headerElem.parentElement;
+            const toggleElem = headerElem.querySelector(".toggle");
+            const childContainer = groupElem.querySelector(".group-children") || groupElem.querySelector(".arguments");
+            if (childContainer) {
+                if (childContainer.style.display === "none") {
+                    childContainer.style.display = "block";
+                    toggleElem.textContent = "[-]";
+                } else {
+                    childContainer.style.display = "none";
+                    toggleElem.textContent = "[+]";
+                }
+            }
+        }
+
+        function toggleAllGroups() {
+            const btn = document.getElementById("toggleAll");
+            const groups = document.querySelectorAll("#groupContainer .group");
+            const expand = btn.textContent === "すべて展開";
+            groups.forEach(group => {
+                const header = group.querySelector(".group-header");
+                const toggleElem = header.querySelector(".toggle");
+                const childContainer = group.querySelector(".group-children") || group.querySelector(".arguments");
+                if (childContainer) {
+                    childContainer.style.display = expand ? "block" : "none";
+                    toggleElem.textContent = expand ? "[-]" : "[+]";
+                }
+            });
+            btn.textContent = expand ? "すべて閉じる" : "すべて展開";
+        }
+    </script>
+</body>
+
+</html>

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -5,18 +5,15 @@ import openai
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from fastapi.responses import FileResponse, ORJSONResponse
 from fastapi.security.api_key import APIKeyHeader
-
 from src.config import settings
-from src.schemas.admin_report import ReportInput, ReportMetadataUpdate, ReportVisibilityUpdate
+from src.schemas.admin_report import (ReportInput, ReportMetadataUpdate,
+                                      ReportVisibilityUpdate)
 from src.schemas.report import Report, ReportStatus
 from src.services.llm_models import get_models_by_provider
 from src.services.report_launcher import launch_report_generation
-from src.services.report_status import (
-    load_status_as_reports,
-    set_status,
-    update_report_metadata,
-    update_report_visibility_state,
-)
+from src.services.report_status import (load_status_as_reports, set_status,
+                                        update_report_metadata,
+                                        update_report_visibility_state)
 from src.utils.logger import setup_logger
 
 slogger = setup_logger()
@@ -62,6 +59,12 @@ async def download_comments_csv(slug: str, api_key: str = Depends(verify_admin_a
         raise HTTPException(status_code=404, detail="CSV file not found")
     return FileResponse(path=str(csv_path), media_type="text/csv", filename=f"kouchou_{slug}.csv")
 
+@router.get("/admin/reports/{slug}/simple-html")
+def get_simple_report_html(slug: str):
+    file_path = settings.REPORT_DIR / slug / "simple_report.html"
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Simple report not found.")
+    return FileResponse(file_path, media_type="text/html")
 
 @router.get("/admin/reports/{slug}/status/step-json", dependencies=[Depends(verify_admin_api_key)])
 async def get_current_step(slug: str) -> dict:

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -5,15 +5,18 @@ import openai
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from fastapi.responses import FileResponse, ORJSONResponse
 from fastapi.security.api_key import APIKeyHeader
+
 from src.config import settings
-from src.schemas.admin_report import (ReportInput, ReportMetadataUpdate,
-                                      ReportVisibilityUpdate)
+from src.schemas.admin_report import ReportInput, ReportMetadataUpdate, ReportVisibilityUpdate
 from src.schemas.report import Report, ReportStatus
 from src.services.llm_models import get_models_by_provider
 from src.services.report_launcher import launch_report_generation
-from src.services.report_status import (load_status_as_reports, set_status,
-                                        update_report_metadata,
-                                        update_report_visibility_state)
+from src.services.report_status import (
+    load_status_as_reports,
+    set_status,
+    update_report_metadata,
+    update_report_visibility_state,
+)
 from src.utils.logger import setup_logger
 
 slogger = setup_logger()


### PR DESCRIPTION
# 変更の概要
- レポート作成時にoutpusの場所にsimple_report.htmlを作成する。
- simple_report.htmlを取得するadmin用API追加
- admin用一覧にシンブル版のリンク追加

# スクリーンショット
-
![image](https://github.com/user-attachments/assets/50730948-6601-446a-924c-8b0f9b48a4dc)
![image](https://github.com/user-attachments/assets/d7e0b605-75ff-420f-9b23-d4964204e242)

# 変更の背景
- さくらインターネット　AppRun β版 の無料に便乗しようとしたがストレージの共有（課金が課金してもできないか）で挫折してclientをすてて単独htmlをステートレスに作成すればなんとかと思って作ってみた。が、それもすぐ消えてしまうのでさらに一工夫必要そうでいったんざせつ。

# 関連Issue
なし、いぜんローカルで開けるhtmlとか、あれこで文言を編集とかあったあたりが関係する


# 動作確認の結果
レポート作成を実行し、正常にレポートが作成されることを確認した
さくらインターネット　AppRun β版 にのせて開けることも確認したが、すぐ消えた（コンポーネントの最適化とかがはしって消える？）

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。