### PR TITLE
Feature/auto cluster clean

### DIFF
--- a/client-admin/app/create/api/report.ts
+++ b/client-admin/app/create/api/report.ts
@@ -20,6 +20,15 @@ export async function createReport({
   is_embedded_at_local,
   enable_source_link,
   local_llm_address,
+  skip_extraction,
+  skip_initial_labelling,
+  skip_merge_labelling,
+  skip_overview,
+  auto_cluster_enabled,
+  clusterLv1_min,
+  clusterLv1_max,
+  clusterLv2_min,
+  clusterLv2_max,
 }: {
   input: string;
   question: string;
@@ -35,6 +44,15 @@ export async function createReport({
   is_embedded_at_local: boolean;
   enable_source_link: boolean;
   local_llm_address?: string;
+  skip_extraction?: boolean;
+  skip_initial_labelling?: boolean;
+  skip_merge_labelling?: boolean;
+  skip_overview?: boolean;
+  auto_cluster_enabled?: boolean;
+  clusterLv1_min?: number;
+  clusterLv1_max?: number;
+  clusterLv2_min?: number;
+  clusterLv2_max?: number;
 }): Promise<void> {
   try {
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports`, {
@@ -58,6 +76,15 @@ export async function createReport({
         is_embedded_at_local,
         enable_source_link,
         local_llm_address,
+        skip_extraction,
+        skip_initial_labelling,
+        skip_merge_labelling,
+        skip_overview,
+        auto_cluster_enabled,
+        clusterLv1_min,
+        clusterLv1_max,
+        clusterLv2_min,
+        clusterLv2_max,
       }),
     });
 

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from "@/components/ui/checkbox";
-import { Button, Field, HStack, Input, NativeSelect, Textarea, VStack } from "@chakra-ui/react";
-
+import { Button, Field, Flex, HStack, Input, NativeSelect, Textarea, VStack } from "@chakra-ui/react";
+import { useEffect } from "react";
 /**
  * AI設定セクションコンポーネント
  */
@@ -23,11 +23,19 @@ export function AISettingsSection({
   requiresConnectionSettings,
   isEmbeddedAtLocalDisabled,
   localLLMAddress,
-  setLocalLLMAddress,
+  fetchLocalLLMModels,
   promptSettings,
   isEmbeddedAtLocal,
   onEmbeddedAtLocalChange,
-  fetchLocalLLMModels,
+  setLocalLLMAddress,
+  skipExtraction,
+  setSkipExtraction,
+  skipInitialLabelling,
+  setSkipInitialLabelling,
+  skipMergeLabelling,
+  setSkipMergeLabelling,
+  skipOverview,
+  setSkipOverview,
 }: {
   provider: string;
   model: string;
@@ -61,8 +69,35 @@ export function AISettingsSection({
   };
   isEmbeddedAtLocal: boolean;
   onEmbeddedAtLocalChange: (checked: boolean | "indeterminate") => void;
+
+  // ✅ スキップ系
+  skipExtraction: boolean;
+  setSkipExtraction: (value: boolean) => void;
+  skipInitialLabelling: boolean;
+  setSkipInitialLabelling: (value: boolean) => void;
+  skipMergeLabelling: boolean;
+  setSkipMergeLabelling: (value: boolean) => void;
+  skipOverview: boolean;
+  setSkipOverview: (value: boolean) => void;
 }) {
   const modelOptions = getCurrentModels();
+  // ✅ "使用しない" が選択されたらスキップ設定を全て true にする
+  useEffect(() => {
+    if (provider === "none") {
+      setSkipExtraction(true);
+      setSkipInitialLabelling(true);
+      setSkipMergeLabelling(true);
+      setSkipOverview(true);
+      onEmbeddedAtLocalChange(true);
+    }
+  }, [
+    provider,
+    setSkipExtraction,
+    setSkipInitialLabelling,
+    setSkipMergeLabelling,
+    setSkipOverview,
+    onEmbeddedAtLocalChange,
+  ]);
 
   return (
     <VStack gap={10}>
@@ -80,7 +115,6 @@ export function AISettingsSection({
           元のコメントと要約された意見をCSV形式で出力します。完成したCSVファイルはレポート一覧ページからダウンロードできます。
         </Field.HelperText>
       </Field.Root>
-
       <Field.Root>
         <Field.Label>AIプロバイダー</Field.Label>
         <NativeSelect.Root w={"40%"}>
@@ -89,12 +123,12 @@ export function AISettingsSection({
             <option value={"azure"}>Azure</option>
             <option value={"openrouter"}>OpenRouter</option>
             <option value={"local"}>LocalLLM</option>
+            <option value="none">使用しない</option>
           </NativeSelect.Field>
           <NativeSelect.Indicator />
         </NativeSelect.Root>
         <Field.HelperText>{getProviderDescription()}</Field.HelperText>
       </Field.Root>
-
       {requiresConnectionSettings() && (
         <Field.Root>
           <Field.Label>LocalLLM接続設定</Field.Label>
@@ -120,39 +154,40 @@ export function AISettingsSection({
           </Field.HelperText>
         </Field.Root>
       )}
-
-      <Field.Root>
-        <Field.Label>並列実行数</Field.Label>
-        <HStack>
-          <Button onClick={onDecreaseWorkers} variant="outline">
-            -
-          </Button>
-          <Input type="number" value={workers.toString()} min={1} max={100} onChange={onWorkersChange} />
-          <Button onClick={onIncreaseWorkers} variant="outline">
-            +
-          </Button>
-        </HStack>
-        <Field.HelperText>
-          LLM APIの並列実行数です。値を大きくすることでレポート出力が速くなりますが、
-          APIプロバイダーのTierによってはレートリミットの上限に到達し、レポート出力が失敗する可能性があります。
-        </Field.HelperText>
-      </Field.Root>
-
-      <Field.Root>
-        <Field.Label>AIモデル</Field.Label>
-        <NativeSelect.Root w={"40%"}>
-          <NativeSelect.Field value={model} onChange={onModelChange}>
-            {modelOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </NativeSelect.Field>
-          <NativeSelect.Indicator />
-        </NativeSelect.Root>
-        <Field.HelperText>{getModelDescription()}</Field.HelperText>
-      </Field.Root>
-
+      {provider !== "none" && (
+        <Field.Root>
+          <Field.Label>並列実行数</Field.Label>
+          <HStack>
+            <Button onClick={onDecreaseWorkers} variant="outline">
+              -
+            </Button>
+            <Input type="number" value={workers.toString()} min={1} max={100} onChange={onWorkersChange} />
+            <Button onClick={onIncreaseWorkers} variant="outline">
+              +
+            </Button>
+          </HStack>
+          <Field.HelperText>
+            LLM APIの並列実行数です。値を大きくすることでレポート出力が速くなりますが、
+            APIプロバイダーのTierによってはレートリミットの上限に到達し、レポート出力が失敗する可能性があります。
+          </Field.HelperText>
+        </Field.Root>
+      )}
+      {provider !== "none" && (
+        <Field.Root>
+          <Field.Label>AIモデル</Field.Label>
+          <NativeSelect.Root w={"40%"}>
+            <NativeSelect.Field value={model} onChange={onModelChange}>
+              {modelOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </NativeSelect.Field>
+            <NativeSelect.Indicator />
+          </NativeSelect.Root>
+          <Field.HelperText>{getModelDescription()}</Field.HelperText>
+        </Field.Root>
+      )}
       <Field.Root>
         <Checkbox
           checked={isEmbeddedAtLocal}
@@ -161,18 +196,19 @@ export function AISettingsSection({
             if (checked === "indeterminate") return;
             onEmbeddedAtLocalChange(checked);
           }}
-          disabled={isEmbeddedAtLocalDisabled?.()}
+          disabled={isEmbeddedAtLocalDisabled?.() || provider === "none"}
         >
           埋め込み処理をサーバ内で行う
         </Checkbox>
         <Field.HelperText>
           埋め込み処理をサーバ内で行うことで、APIの利用料金を削減します。
           精度に関しては未検証であり、OpenAIを使った場合と大きく異なる結果になる可能性があります。
-          {isEmbeddedAtLocalDisabled?.() && (
-            <span style={{ color: "red" }}>
-              ※ LocalLLMプロバイダーを選択している場合、この設定は強制的にONになります
-            </span>
-          )}
+          {isEmbeddedAtLocalDisabled?.() ||
+            (provider === "none" && (
+              <span style={{ color: "red" }}>
+                ※ LocalLLMプロバイダーまたは「使用しない」を選択している場合、この設定は強制的にONになります
+              </span>
+            ))}
         </Field.HelperText>
       </Field.Root>
 
@@ -191,45 +227,92 @@ export function AISettingsSection({
          ONにした場合は、CSVのurlカラムの情報を使って、レポートの散布図上でデータ点をクリックすると元のソースにアクセスできます。
         </Field.HelperText>
       </Field.Root>
-
+      {/* 抽出プロンプト */}
       <Field.Root>
-        <Field.Label>抽出プロンプト</Field.Label>
+        <Flex align="center" w="100%">
+          <Field.Label flex="1">抽出プロンプト</Field.Label>
+          <Checkbox
+            checked={skipExtraction}
+            onCheckedChange={({ checked }) => setSkipExtraction(checked === true)}
+            ml="auto"
+            pr={2}
+          >
+            スキップ
+          </Checkbox>
+        </Flex>
         <Textarea
-          h={"150px"}
+          h="150px"
           value={promptSettings.extraction}
           onChange={(e) => promptSettings.setExtraction(e.target.value)}
+          disabled={skipExtraction}
         />
-        <Field.HelperText>AIに提示する抽出プロンプトです(通常は変更不要です)</Field.HelperText>
+        <Field.HelperText>AIに提示する抽出プロンプトです（通常は変更不要です）</Field.HelperText>
       </Field.Root>
 
+      {/* 初期ラベリングプロンプト */}
       <Field.Root>
-        <Field.Label>初期ラベリングプロンプト</Field.Label>
+        <Flex align="center" w="100%">
+          <Field.Label flex="1">初期ラベリングプロンプト</Field.Label>
+          <Checkbox
+            checked={skipInitialLabelling}
+            onCheckedChange={({ checked }) => setSkipInitialLabelling(checked === true)}
+            ml="auto"
+            pr={2}
+          >
+            スキップ
+          </Checkbox>
+        </Flex>
         <Textarea
-          h={"150px"}
+          h="150px"
           value={promptSettings.initialLabelling}
           onChange={(e) => promptSettings.setInitialLabelling(e.target.value)}
+          disabled={skipInitialLabelling}
         />
-        <Field.HelperText>AIに提示する初期ラベリングプロンプトです(通常は変更不要です)</Field.HelperText>
+        <Field.HelperText>AIに提示する初期ラベリングプロンプトです（通常は変更不要です）</Field.HelperText>
       </Field.Root>
 
+      {/* 統合ラベリングプロンプト */}
       <Field.Root>
-        <Field.Label>統合ラベリングプロンプト</Field.Label>
+        <Flex align="center" w="100%">
+          <Field.Label flex="1">統合ラベリングプロンプト</Field.Label>
+          <Checkbox
+            checked={skipMergeLabelling}
+            onCheckedChange={({ checked }) => setSkipMergeLabelling(checked === true)}
+            ml="auto"
+            pr={2}
+          >
+            スキップ
+          </Checkbox>
+        </Flex>
         <Textarea
-          h={"150px"}
+          h="150px"
           value={promptSettings.mergeLabelling}
           onChange={(e) => promptSettings.setMergeLabelling(e.target.value)}
+          disabled={skipMergeLabelling}
         />
-        <Field.HelperText>AIに提示する統合ラベリングプロンプトです(通常は変更不要です)</Field.HelperText>
+        <Field.HelperText>AIに提示する統合ラベリングプロンプトです（通常は変更不要です）</Field.HelperText>
       </Field.Root>
 
+      {/* 要約プロンプト */}
       <Field.Root>
-        <Field.Label>要約プロンプト</Field.Label>
+        <Flex align="center" w="100%">
+          <Field.Label flex="1">要約プロンプト</Field.Label>
+          <Checkbox
+            checked={skipOverview}
+            onCheckedChange={({ checked }) => setSkipOverview(checked === true)}
+            ml="auto"
+            pr={2}
+          >
+            スキップ
+          </Checkbox>
+        </Flex>
         <Textarea
-          h={"150px"}
+          h="150px"
           value={promptSettings.overview}
           onChange={(e) => promptSettings.setOverview(e.target.value)}
+          disabled={skipOverview}
         />
-        <Field.HelperText>AIに提示する要約プロンプトです(通常は変更不要です)</Field.HelperText>
+        <Field.HelperText>AIに提示する要約プロンプトです（通常は変更不要です）</Field.HelperText>
       </Field.Root>
     </VStack>
   );

--- a/client-admin/app/create/components/ClusterSettingsSection.tsx
+++ b/client-admin/app/create/components/ClusterSettingsSection.tsx
@@ -1,5 +1,6 @@
-import { Button, Field, HStack, Input, Text } from "@chakra-ui/react";
-import { ChevronRightIcon } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, HStack, Input, Text } from "@chakra-ui/react";
+import type { Warning } from "../hooks/useClusterSettings";
 import type { ClusterSettings } from "../types";
 
 export function ClusterSettingsSection({
@@ -9,6 +10,17 @@ export function ClusterSettingsSection({
   autoAdjusted,
   onLv1Change,
   onLv2Change,
+  autoClusterEnabled,
+  clusterLv1Min,
+  clusterLv1Max,
+  clusterLv2Min,
+  clusterLv2Max,
+  onAutoClusterToggle,
+  onLv1MinChange,
+  onLv1MaxChange,
+  onLv2MinChange,
+  onLv2MaxChange,
+  manualWarnings,
 }: {
   clusterLv1: number;
   clusterLv2: number;
@@ -16,66 +28,125 @@ export function ClusterSettingsSection({
   autoAdjusted: boolean;
   onLv1Change: (value: number) => void;
   onLv2Change: (value: number) => void;
+  autoClusterEnabled: boolean;
+  clusterLv1Min: number;
+  clusterLv1Max: number;
+  clusterLv2Min: number;
+  clusterLv2Max: number;
+  onAutoClusterToggle: (value: boolean) => void;
+  onLv1MinChange: (value: number) => void;
+  onLv1MaxChange: (value: number) => void;
+  onLv2MinChange: (value: number) => void;
+  onLv2MaxChange: (value: number) => void;
+  manualWarnings: Warning[];
 }) {
   if (!recommendedClusters) return null;
 
+  const lv1HasWarning = manualWarnings.some((w) => w.field === "lv1");
+  const lv2HasWarning = manualWarnings.some((w) => w.field === "lv2");
+
   return (
     <Field.Root mt={4}>
-      <Field.Label>意見グループ数設定</Field.Label>
-      <HStack w={"100%"}>
-        <Button onClick={() => onLv1Change(clusterLv1 - 1)} variant="outline">
-          -
-        </Button>
-        <Input
-          type="number"
-          value={clusterLv1.toString()}
-          min={2}
-          max={40}
-          onChange={(e) => {
-            const v = Number(e.target.value);
-            if (!Number.isNaN(v)) {
-              onLv1Change(v);
-            }
-          }}
-        />
-        <Button onClick={() => onLv1Change(clusterLv1 + 1)} variant="outline">
-          +
-        </Button>
-        <ChevronRightIcon width="100px" />
-        <Button onClick={() => onLv2Change(clusterLv2 - 1)} variant="outline">
-          -
-        </Button>
-        <Input
-          type="number"
-          value={clusterLv2.toString()}
-          min={2}
-          max={1000}
-          onChange={(e) => {
-            const inputValue = e.target.value;
-            if (inputValue === "") return;
-            const v = Number(inputValue);
-            if (!Number.isNaN(v)) {
-              onLv2Change(v);
-            }
-          }}
-          onBlur={(e) => {
-            const v = Number(e.target.value);
-            if (!Number.isNaN(v)) {
-              onLv2Change(v);
-            }
-          }}
-        />
-        <Button onClick={() => onLv2Change(clusterLv2 + 1)} variant="outline">
-          +
-        </Button>
+      <HStack justify="space-between" w="100%" align="center">
+        <Field.Label>意見グループ数設定</Field.Label>
+        <Checkbox checked={autoClusterEnabled} onCheckedChange={({ checked }) => onAutoClusterToggle(checked === true)}>
+          グループ数を自動で決定する
+        </Checkbox>
       </HStack>
-      <Field.HelperText>
-        階層ごとの意見グループ生成数です。初期値はコメント数に基づいた推奨意見グループ数です。
-      </Field.HelperText>
-      {autoAdjusted && (
-        <Text color="orange.500" fontSize="sm" mt={2}>
-          第2階層の意見グループ数が自動調整されました。第2階層の意見グループ数は第1階層の意見グループ数の2倍以上に設定してください。
+
+      <HStack mt={3} flexWrap="wrap" w="100%" align="center">
+        <Text fontSize="sm" w="100px">
+          第一階層
         </Text>
+        {autoClusterEnabled ? (
+          <>
+            <Input
+              type="number"
+              value={clusterLv1Min.toString()}
+              onChange={(e) => onLv1MinChange(Number(e.target.value))}
+              size="sm"
+              w="81px"
+            />
+            <Text fontSize="sm" mx={1}>
+              ～
+            </Text>
+            <Input
+              type="number"
+              value={clusterLv1Max.toString()}
+              onChange={(e) => onLv1MaxChange(Number(e.target.value))}
+              size="sm"
+              w="81px"
+            />
+            <Text fontSize="sm" mx={3} w="40px" textAlign="center">
+              ▶
+            </Text>
+            <Text fontSize="sm" w="100px">
+              第二階層
+            </Text>
+            <Input
+              type="number"
+              value={clusterLv2Min.toString()}
+              onChange={(e) => onLv2MinChange(Number(e.target.value))}
+              size="sm"
+              w="81px"
+            />
+            <Text fontSize="sm" mx={1}>
+              ～
+            </Text>
+            <Input
+              type="number"
+              value={clusterLv2Max.toString()}
+              onChange={(e) => onLv2MaxChange(Number(e.target.value))}
+              size="sm"
+              w="81px"
+            />
+          </>
+        ) : (
+          <>
+            <Input
+              type="number"
+              value={clusterLv1.toString()}
+              onChange={(e) => onLv1Change(Number(e.target.value))}
+              min={clusterLv1Min}
+              max={clusterLv1Max}
+              size="sm"
+              w="200px"
+            />
+            <Text fontSize="sm" mx={3} w="40px" textAlign="center">
+              ▶
+            </Text>
+            <Text fontSize="sm" w="100px">
+              第二階層
+            </Text>
+            <Input
+              type="number"
+              value={clusterLv2.toString()}
+              onChange={(e) => onLv2Change(Number(e.target.value))}
+              min={clusterLv2Min}
+              max={clusterLv2Max}
+              size="sm"
+              w="200px"
+            />
+          </>
+        )}
+      </HStack>
+
+      {manualWarnings.map((w) => (
+        <Text key={`${w.field}-${w.message}`} fontSize="sm" color="orange.500">
+          {w.message}
+        </Text>
+      ))}
+
+      {autoClusterEnabled ? (
+        <Field.HelperText mt={2}>
+          階層ごとの意見グループ生成数を「下限 ～ 上限」の範囲で自動的に評価し、最適な数を決定します。
+        </Field.HelperText>
+      ) : (
+        <>
+          <Field.HelperText mt={2}>
+            階層ごとの意見グループ生成数を手動で設定します。初期値はコメント数に基づいた推奨意見グループ数です。
+          </Field.HelperText>
+        </>
       )}
     </Field.Root>
   );

--- a/client-admin/app/create/components/CsvFileTab.tsx
+++ b/client-admin/app/create/components/CsvFileTab.tsx
@@ -108,6 +108,17 @@ export function CsvFileTab({
           autoAdjusted={clusterSettings.autoAdjusted}
           onLv1Change={clusterSettings.handleLv1Change}
           onLv2Change={clusterSettings.handleLv2Change}
+          autoClusterEnabled={clusterSettings.autoClusterEnabled}
+          clusterLv1Min={clusterSettings.clusterLv1Min}
+          clusterLv1Max={clusterSettings.clusterLv1Max}
+          clusterLv2Min={clusterSettings.clusterLv2Min}
+          clusterLv2Max={clusterSettings.clusterLv2Max}
+          onAutoClusterToggle={clusterSettings.handleAutoClusterToggle}
+          onLv1MinChange={clusterSettings.handleLv1MinChange}
+          onLv1MaxChange={clusterSettings.handleLv1MaxChange}
+          onLv2MinChange={clusterSettings.handleLv2MinChange}
+          onLv2MaxChange={clusterSettings.handleLv2MaxChange}
+          manualWarnings={clusterSettings.manualWarnings}
         />
       </VStack>
     </Tabs.Content>

--- a/client-admin/app/create/components/SpreadsheetTab.tsx
+++ b/client-admin/app/create/components/SpreadsheetTab.tsx
@@ -92,6 +92,17 @@ export function SpreadsheetTab({
             autoAdjusted={clusterSettings.autoAdjusted}
             onLv1Change={clusterSettings.handleLv1Change}
             onLv2Change={clusterSettings.handleLv2Change}
+            autoClusterEnabled={clusterSettings.autoClusterEnabled}
+            clusterLv1Min={clusterSettings.clusterLv1Min}
+            clusterLv1Max={clusterSettings.clusterLv1Max}
+            clusterLv2Min={clusterSettings.clusterLv2Min}
+            clusterLv2Max={clusterSettings.clusterLv2Max}
+            onAutoClusterToggle={clusterSettings.handleAutoClusterToggle}
+            onLv1MinChange={clusterSettings.handleLv1MinChange}
+            onLv1MaxChange={clusterSettings.handleLv1MaxChange}
+            onLv2MinChange={clusterSettings.handleLv2MinChange}
+            onLv2MaxChange={clusterSettings.handleLv2MaxChange}
+            manualWarnings={clusterSettings.manualWarnings}
           />
         </Field.Root>
 

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -1,7 +1,7 @@
 import { toaster } from "@/components/ui/toaster";
 import { type ChangeEvent, useEffect, useState } from "react";
 
-export type Provider = "openai" | "azure" | "openrouter" | "local";
+export type Provider = "openai" | "azure" | "openrouter" | "local" | "none";
 
 export interface ModelOption {
   value: string;
@@ -124,6 +124,10 @@ export function useAISettings() {
 
   const [openRouterModels, setOpenRouterModels] = useState<ModelOption[]>([]);
   const [localLLMModels, setLocalLLMModels] = useState<ModelOption[]>([]);
+  const [skipExtraction, setSkipExtraction] = useState(false);
+  const [skipInitialLabelling, setSkipInitialLabelling] = useState(false);
+  const [skipMergeLabelling, setSkipMergeLabelling] = useState(false);
+  const [skipOverview, setSkipOverview] = useState(false);
 
   useEffect(() => {
     saveToStorage(STORAGE_KEYS.PROVIDER, provider);
@@ -215,6 +219,11 @@ export function useAISettings() {
       models: localLLMModels,
       description: "ローカルで実行されているLLMサーバーに接続します。",
       requiresConnection: true,
+    },
+    none: {
+      models: [],
+      description:
+        "AIプロバイダーを使用せず、エンベディングのみローカルで実行されます。すべてのLLM処理はスキップされます。",
     },
   };
 
@@ -367,5 +376,13 @@ export function useAISettings() {
     resetAISettings,
     setIsEmbeddedAtLocal,
     fetchLocalLLMModels,
+    skipExtraction,
+    setSkipExtraction,
+    skipInitialLabelling,
+    setSkipInitialLabelling,
+    skipMergeLabelling,
+    setSkipMergeLabelling,
+    skipOverview,
+    setSkipOverview,
   };
 }

--- a/client-admin/app/create/hooks/useClusterSettings.ts
+++ b/client-admin/app/create/hooks/useClusterSettings.ts
@@ -1,101 +1,213 @@
 import { useCallback, useState } from "react";
 import type { ClusterSettings } from "../types";
+import { CLUSTER_LIMITS, validateClusterSettings } from "./validateClusterSettings";
+import { validateManualClusterCounts } from "./validateManualClusterCounts";
 
-// カスタムフック: 意見グループ設定の管理
-export function useClusterSettings(initialLv1 = 5, initialLv2 = 50) {
+export type Warning = {
+  field: "lv1" | "lv2";
+  message: string;
+};
+
+export function useClusterSettings(
+  initialLv1 = Math.floor(CLUSTER_LIMITS.level1.max / 2),
+  initialLv2 = Math.floor(CLUSTER_LIMITS.level2.max / 2),
+) {
+  // クラスタ数状態
   const [clusterLv1, setClusterLv1] = useState<number>(initialLv1);
   const [clusterLv2, setClusterLv2] = useState<number>(initialLv2);
-  const [recommendedClusters, setRecommendedClusters] = useState<ClusterSettings | null>(null);
-  const [autoAdjusted, setAutoAdjusted] = useState<boolean>(false);
+  const bounds = {
+    level1: { min: CLUSTER_LIMITS.level1.min, max: CLUSTER_LIMITS.level1.max },
+    level2: { min: CLUSTER_LIMITS.level2.min, max: CLUSTER_LIMITS.level2.max },
+  };
+  // 自動モード時の入力範囲
+  const [clusterLv1Min, setClusterLv1Min] = useState<number>(CLUSTER_LIMITS.level1.min);
+  const [clusterLv1Max, setClusterLv1Max] = useState<number>(CLUSTER_LIMITS.level1.max);
+  const [clusterLv2Min, setClusterLv2Min] = useState<number>(CLUSTER_LIMITS.level2.min);
+  const [clusterLv2Max, setClusterLv2Max] = useState<number>(CLUSTER_LIMITS.level2.max);
 
-  // コメント数から意見グループ数を計算
+  // 推奨クラスタ数の保持
+  const [recommendedClusters, setRecommendedClusters] = useState<ClusterSettings | null>(null);
+
+  // 補正検知フラグ
+  const [autoAdjusted, setAutoAdjusted] = useState<boolean>(false);
+  const [autoClusterEnabled, setAutoClusterEnabled] = useState<boolean>(false);
+
+  // 手動入力時の警告メッセージ
+  const [manualWarnings, setManualWarnings] = useState<Warning[]>([]);
+
+  /**
+   * Lv1/Lv2 の Min/Max 入力変更を一元処理
+   */
+  const handleRangeChange = useCallback(
+    (field: "lv1" | "lv2", side: "Min" | "Max", value: number) => {
+      const input = {
+        lv1Min: clusterLv1Min,
+        lv1Max: clusterLv1Max,
+        lv2Min: clusterLv2Min,
+        lv2Max: clusterLv2Max,
+      };
+      if (field === "lv1") {
+        if (side === "Min") input.lv1Min = value;
+        else input.lv1Max = value;
+      } else {
+        if (side === "Min") input.lv2Min = value;
+        else input.lv2Max = value;
+      }
+
+      const result = validateClusterSettings(input);
+      setClusterLv1Min(result.lv1Min);
+      setClusterLv1Max(result.lv1Max);
+      setClusterLv2Min(result.lv2Min);
+      setClusterLv2Max(result.lv2Max);
+      setManualWarnings(result.warnings);
+      setAutoAdjusted(result.warnings.length > 0);
+    },
+    [clusterLv1Min, clusterLv1Max, clusterLv2Min, clusterLv2Max],
+  );
+
+  const handleLv1MinChange = useCallback(
+    (value: number) => handleRangeChange("lv1", "Min", value),
+    [handleRangeChange],
+  );
+  const handleLv1MaxChange = useCallback(
+    (value: number) => handleRangeChange("lv1", "Max", value),
+    [handleRangeChange],
+  );
+  const handleLv2MinChange = useCallback(
+    (value: number) => handleRangeChange("lv2", "Min", value),
+    [handleRangeChange],
+  );
+  const handleLv2MaxChange = useCallback(
+    (value: number) => handleRangeChange("lv2", "Max", value),
+    [handleRangeChange],
+  );
+
+  /**
+   * 手動モード（AutoCluster無効時）でのクラスタ数変更
+   */
+  // --- 第1階層ハンドラ ---
+  function handleLv1Change(value: number) {
+    const { clusterLv1: newLv1, clusterLv2: newLv2, warnings } = validateManualClusterCounts(value, clusterLv2, bounds);
+
+    setClusterLv1(newLv1);
+    setClusterLv2(newLv2);
+    setManualWarnings(warnings);
+  }
+
+  // --- 第2階層ハンドラ ---
+  function handleLv2Change(value: number) {
+    const { clusterLv1: newLv1, clusterLv2: newLv2, warnings } = validateManualClusterCounts(clusterLv1, value, bounds);
+
+    setClusterLv1(newLv1); // Lv1 は変更しないが戻り値に含まれる
+    setClusterLv2(newLv2);
+    setManualWarnings(warnings);
+  }
+
+  /**
+   * コメント数から推奨クラスタ数を計算
+   */
   const calculateRecommendedClusters = useCallback((commentCount: number) => {
-    const lv1 = Math.max(2, Math.min(10, Math.round(Math.cbrt(commentCount))));
-    const lv2 = Math.max(2, Math.min(1000, Math.round(lv1 * lv1)));
+    const lv1 = Math.max(
+      CLUSTER_LIMITS.level1.min,
+      Math.min(Math.floor(CLUSTER_LIMITS.level1.max / 2), Math.round(Math.cbrt(commentCount))),
+    );
+    const lv2 = Math.max(CLUSTER_LIMITS.level2.min, Math.min(CLUSTER_LIMITS.level2.max, Math.round(lv1 * lv1)));
     return { lv1, lv2 };
   }, []);
 
+  /**
+   * 推奨クラスタ数を適用し、AutoClusterモードの範囲にも反映
+   */
   const setRecommended = useCallback(
     (commentCount: number) => {
-      const recommended = calculateRecommendedClusters(commentCount);
-      setRecommendedClusters(recommended);
-      setClusterLv1(recommended.lv1);
-      setClusterLv2(recommended.lv2);
-      return recommended;
+      const rec = calculateRecommendedClusters(commentCount);
+      setRecommendedClusters(rec);
+      setClusterLv1(rec.lv1);
+      setClusterLv2(rec.lv2);
+
+      const result = validateClusterSettings({
+        lv1Min: Math.floor(rec.lv1 / 2),
+        lv1Max: rec.lv1 * 2,
+        lv2Min: Math.max(rec.lv1 * 2 + 1, Math.floor(rec.lv2 / 2)),
+        lv2Max: Math.min(rec.lv2 * 2, CLUSTER_LIMITS.level2.max),
+      });
+      setClusterLv1Min(result.lv1Min);
+      setClusterLv1Max(result.lv1Max);
+      setClusterLv2Min(result.lv2Min);
+      setClusterLv2Max(result.lv2Max);
+      setManualWarnings(result.warnings);
+      setAutoAdjusted(result.warnings.length > 0);
+
+      return rec;
     },
     [calculateRecommendedClusters],
   );
 
-  const handleLv1Change = useCallback(
-    (newValue: number) => {
-      const limitedValue = Math.max(2, Math.min(40, newValue));
-      setClusterLv1(limitedValue);
-
-      // 第一階層の意見グループ数 * 2 > 第二階層の意見グループ数の場合のみ、第二階層の値を更新
-      const newClusterLv2 = limitedValue * 2;
-      if (newClusterLv2 > clusterLv2) {
-        setClusterLv2(newClusterLv2);
-        setAutoAdjusted(true);
-
-        // 推奨意見グループ数表示を更新（nullでない場合のみ）
-        if (recommendedClusters) {
-          setRecommendedClusters({
-            lv1: limitedValue,
-            lv2: newClusterLv2,
-          });
-        }
-      } else if (recommendedClusters) {
-        setRecommendedClusters({
-          lv1: limitedValue,
-          lv2: clusterLv2,
+  /**
+   * AutoClusterモード切替
+   */
+  const handleAutoClusterToggle = useCallback(
+    (enabled: boolean) => {
+      setAutoClusterEnabled(enabled);
+      if (enabled) {
+        const result = validateClusterSettings({
+          lv1Min: clusterLv1Min,
+          lv1Max: clusterLv1Max,
+          lv2Min: clusterLv2Min,
+          lv2Max: clusterLv2Max,
         });
+        setClusterLv1Min(result.lv1Min);
+        setClusterLv1Max(result.lv1Max);
+        setClusterLv2Min(result.lv2Min);
+        setClusterLv2Max(result.lv2Max);
+        setManualWarnings(result.warnings);
+        setAutoAdjusted(result.warnings.length > 0);
       }
     },
-    [clusterLv2, recommendedClusters],
+    [clusterLv1Min, clusterLv1Max, clusterLv2Min, clusterLv2Max],
   );
 
-  const handleLv2Change = useCallback(
-    (newValue: number) => {
-      let limitedValue = Math.max(2, Math.min(1000, newValue));
-
-      // 第二階層の値が第一階層の値の2倍未満の場合は自動調整
-      if (limitedValue < clusterLv1 * 2) {
-        limitedValue = clusterLv1 * 2;
-        setAutoAdjusted(true);
-      } else {
-        setAutoAdjusted(false);
-      }
-
-      setClusterLv2(limitedValue);
-
-      // 推奨意見グループ数表示を更新（nullでない場合のみ）
-      if (recommendedClusters) {
-        setRecommendedClusters({
-          lv1: recommendedClusters.lv1,
-          lv2: limitedValue,
-        });
-      }
-    },
-    [clusterLv1, recommendedClusters],
-  );
-
-  // リセット
+  /**
+   * すべての設定を初期状態にリセット
+   */
   const resetClusterSettings = useCallback(() => {
     setClusterLv1(initialLv1);
     setClusterLv2(initialLv2);
     setRecommendedClusters(null);
     setAutoAdjusted(false);
+    setAutoClusterEnabled(false);
+    setManualWarnings([]);
+    setClusterLv1Min(CLUSTER_LIMITS.level1.min);
+    setClusterLv1Max(CLUSTER_LIMITS.level1.max);
+    setClusterLv2Min(CLUSTER_LIMITS.level2.min);
+    setClusterLv2Max(CLUSTER_LIMITS.level2.max);
   }, [initialLv1, initialLv2]);
 
   return {
+    // 現在値
     clusterLv1,
     clusterLv2,
+    // AutoCluster範囲
+    clusterLv1Min,
+    clusterLv1Max,
+    clusterLv2Min,
+    clusterLv2Max,
+    // 推奨クラスタ数
     recommendedClusters,
+    // フラグ
     autoAdjusted,
-    calculateRecommendedClusters,
-    setRecommended,
+    autoClusterEnabled,
+    // 警告メッセージ
+    manualWarnings,
+    // ハンドラ
     handleLv1Change,
     handleLv2Change,
+    handleLv1MinChange,
+    handleLv1MaxChange,
+    handleLv2MinChange,
+    handleLv2MaxChange,
+    setRecommended,
+    handleAutoClusterToggle,
     resetClusterSettings,
   };
 }

--- a/client-admin/app/create/hooks/validateClusterSettings.ts
+++ b/client-admin/app/create/hooks/validateClusterSettings.ts
@@ -1,0 +1,107 @@
+import type { Warning } from "./useClusterSettings";
+export const CLUSTER_LIMITS = {
+  level1: { min: 2, max: 40 },
+  level2: { min: 4, max: 1000 },
+};
+
+type Range = { min: number; max: number };
+type Level = "lv1" | "lv2";
+
+interface ValidateInput {
+  lv1Min: number;
+  lv1Max: number;
+  lv2Min: number;
+  lv2Max: number;
+}
+interface ValidateOutput extends ValidateInput {
+  warnings: Warning[];
+}
+
+/** 値を [min,max] で補正し、補正時に警告を返す */
+function clamp(field: Level, value: number, range: Range, label: string): { value: number; warning?: Warning } {
+  if (value < range.min) {
+    return {
+      value: range.min,
+      warning: {
+        field,
+        message: `${label}の値は ${range.min}～${range.max} の範囲で指定してください。${range.min} に補正しました。`,
+      },
+    };
+  }
+  if (value > range.max) {
+    return {
+      value: range.max,
+      warning: {
+        field,
+        message: `${label}の値は ${range.min}～${range.max} の範囲で指定してください。${range.max} に補正しました。`,
+      },
+    };
+  }
+  return { value };
+}
+
+/** min と max の大小関係を保証し、必要なら補正＆警告 */
+function ensureOrder(
+  field: Level,
+  min: number,
+  max: number,
+  labelMin: string,
+  labelMax: string,
+): { min: number; max: number; warning?: Warning } {
+  if (min > max) {
+    // min を max にあわせる
+    return {
+      min: max,
+      max,
+      warning: { field, message: `${labelMin} が ${labelMax} を超えたため両方 ${max} に補正しました。` },
+    };
+  }
+  return { min, max };
+}
+
+export function validateClusterSettings(input: ValidateInput): ValidateOutput {
+  const warnings: Warning[] = [];
+  // Lv1
+  const r1 = CLUSTER_LIMITS.level1;
+  let { value: lv1Min, warning: w1 } = clamp("lv1", input.lv1Min, r1, "Lv1最小");
+  if (w1) warnings.push(w1);
+  let { value: lv1Max, warning: w2 } = clamp("lv1", input.lv1Max, r1, "Lv1最大");
+  if (w2) warnings.push(w2);
+  const ord1 = ensureOrder("lv1", lv1Min, lv1Max, "Lv1最小", "Lv1最大");
+  if (ord1.warning) {
+    lv1Min = ord1.min;
+    lv1Max = ord1.max;
+    warnings.push(ord1.warning);
+  }
+  // Lv2
+  const r2 = CLUSTER_LIMITS.level2;
+  let { value: lv2Min, warning: w3 } = clamp("lv2", input.lv2Min, r2, "Lv2最小");
+  if (w3) warnings.push(w3);
+  let { value: lv2Max, warning: w4 } = clamp("lv2", input.lv2Max, r2, "Lv2最大");
+  if (w4) warnings.push(w4);
+  const ord2 = ensureOrder("lv2", lv2Min, lv2Max, "Lv2最小", "Lv2最大");
+  if (ord2.warning) {
+    lv2Min = ord2.min;
+    lv2Max = ord2.max;
+    warnings.push(ord2.warning);
+  }
+  //  Lv1.max < Lv2.min を保証 ──
+  // ── 追加: 第1階層の最大値を跨がないように Lv2.min と Lv2.max を補正 ──
+  if (lv2Min <= lv1Max) {
+    const correctedMin = lv1Max + 1;
+    warnings.push({
+      field: "lv2",
+      message: `第2階層の最小値は第1階層の最大値より大きく指定してください。${correctedMin} に補正しました。`,
+    });
+    lv2Min = correctedMin;
+  }
+  if (lv2Max <= lv1Max) {
+    const correctedMax = lv1Max + 1;
+    warnings.push({
+      field: "lv2",
+      message: `第2階層の最大値は第1階層の最大値より大きく指定してください。${correctedMax} に補正しました。`,
+    });
+    lv2Max = correctedMax;
+  }
+  return { lv1Min, lv1Max, lv2Min, lv2Max, warnings };
+}

--- a/client-admin/app/create/hooks/validateManualClusterCounts.ts
+++ b/client-admin/app/create/hooks/validateManualClusterCounts.ts
@@ -1,0 +1,60 @@
+import type { Warning } from "./useClusterSettings";
+
+/**
+ * 手動モード向けクラスタ数のチェック＆補正
+ * @param clusterLv1 - 第1階層クラスタ数
+ * @param clusterLv2 - 第2階層クラスタ数
+ * @param bounds - 第1/第2階層の許容範囲
+ * @returns 補正後のクラスタ数と警告リスト
+ */
+export function validateManualClusterCounts(
+  clusterLv1: number,
+  clusterLv2: number,
+  bounds: { level1: { min: number; max: number }; level2: { min: number; max: number } },
+): { clusterLv1: number; clusterLv2: number; warnings: Warning[] } {
+  const warnings: Warning[] = [];
+
+  // 1. 第1階層の範囲チェック＆補正
+  let clampedLv1 = clusterLv1;
+  if (clampedLv1 < bounds.level1.min) {
+    clampedLv1 = bounds.level1.min;
+    warnings.push({
+      field: "lv1",
+      message: `第1階層の値は ${bounds.level1.min}〜${bounds.level1.max} の範囲で指定してください。${bounds.level1.min}に補正しました。`,
+    });
+  } else if (clampedLv1 > bounds.level1.max) {
+    clampedLv1 = bounds.level1.max;
+    warnings.push({
+      field: "lv1",
+      message: `第1階層の値は ${bounds.level1.min}〜${bounds.level1.max} の範囲で指定してください。${bounds.level1.max}に補正しました。`,
+    });
+  }
+
+  // 2. 第2階層の範囲チェック＆補正
+  let clampedLv2 = clusterLv2;
+  if (clampedLv2 < bounds.level2.min) {
+    clampedLv2 = bounds.level2.min;
+    warnings.push({
+      field: "lv2",
+      message: `第2階層の値は ${bounds.level2.min}〜${bounds.level2.max} の範囲で指定してください。${bounds.level2.min}に補正しました。`,
+    });
+  } else if (clampedLv2 > bounds.level2.max) {
+    clampedLv2 = bounds.level2.max;
+    warnings.push({
+      field: "lv2",
+      message: `第2階層の値は ${bounds.level2.min}〜${bounds.level2.max} の範囲で指定してください。${bounds.level2.max}に補正しました。`,
+    });
+  }
+
+  // 3. 第1階層に紐づく第2階層の依存チェック (Lv2 >= Lv1*2)
+  const minLv2 = clampedLv1 * 2;
+  if (clampedLv2 < minLv2) {
+    clampedLv2 = minLv2;
+    warnings.push({
+      field: "lv2",
+      message: `第2階層の値は第1階層の2倍以上に指定してください。${minLv2}に補正しました。`,
+    });
+  }
+
+  return { clusterLv1: clampedLv1, clusterLv2: clampedLv2, warnings };
+}

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -18,8 +18,26 @@ import { useInputData } from "./hooks/useInputData";
 import { usePromptSettings } from "./hooks/usePromptSettings";
 import { type CsvData, parseCsv } from "./parseCsv";
 import { showErrorToast } from "./utils/error-handler";
+import { generateDefaultQuestionTitle } from "./utils/generateTitle";
 import { validateFormValues } from "./utils/validation";
 
+function generateClusterList(min: number, topMax: number, bottomMax: number): number[] {
+  const clusters: number[] = [];
+
+  let current = min;
+  while (current <= topMax) {
+    clusters.push(current);
+    current *= 2;
+  }
+
+  current = topMax + 1;
+  while (current <= bottomMax) {
+    clusters.push(current);
+    current *= 2;
+  }
+
+  return clusters;
+}
 /**
  * レポート作成ページ
  */
@@ -83,13 +101,13 @@ export default function Page() {
         const parsed = await parseCsv(inputData.csv);
         comments = parsed.map((row, index) => {
           const rowData = row as unknown as Record<string, unknown>;
-          
+
           // コメントオブジェクトの作成（基本フィールド）
           const comment: CsvData = {
             id: row.id || `csv-${index + 1}`,
             comment: rowData[inputData.selectedCommentColumn] as string,
-            source: rowData.source as string || null,
-            url: rowData.url as string || null,
+            source: (rowData.source as string) || null,
+            url: (rowData.url as string) || null,
           };
 
           // 選択された属性カラムの値を直接追加（"attribute" プレフィックス付き）
@@ -151,11 +169,21 @@ export default function Page() {
 
     try {
       const promptData = promptSettings.getPromptSettings();
+      // ✅ タイトルと調査概要の補完
+      const input = basicInfo.input;
+      let question = basicInfo.question.trim();
+      let intro = basicInfo.intro.trim();
 
+      if (question === "") {
+        question = generateDefaultQuestionTitle({ inputData, clusterSettings, aiSettings });
+      }
+      if (intro === "") {
+        intro = "";
+      }
       await createReport({
         input: basicInfo.input,
-        question: basicInfo.question,
-        intro: basicInfo.intro,
+        question,
+        intro,
         comments,
         cluster: [clusterSettings.clusterLv1, clusterSettings.clusterLv2],
         provider: aiSettings.provider,
@@ -167,6 +195,15 @@ export default function Page() {
         is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
         enable_source_link: aiSettings.enableSourceLink,
         local_llm_address: aiSettings.provider === "local" ? aiSettings.localLLMAddress : undefined,
+        skip_extraction: aiSettings.skipExtraction,
+        skip_initial_labelling: aiSettings.skipInitialLabelling,
+        skip_merge_labelling: aiSettings.skipMergeLabelling,
+        skip_overview: aiSettings.skipOverview,
+        auto_cluster_enabled: clusterSettings.autoClusterEnabled,
+        clusterLv1_min: clusterSettings.clusterLv1Min,
+        clusterLv1_max: clusterSettings.clusterLv1Max,
+        clusterLv2_min: clusterSettings.clusterLv2Min,
+        clusterLv2_max: clusterSettings.clusterLv2Max,
       });
 
       toaster.create({
@@ -296,6 +333,15 @@ export default function Page() {
               requiresConnectionSettings={aiSettings.requiresConnectionSettings}
               isEmbeddedAtLocalDisabled={aiSettings.isEmbeddedAtLocalDisabled}
               promptSettings={promptSettings}
+              // ✅ スキップ系の追加
+              skipExtraction={aiSettings.skipExtraction}
+              setSkipExtraction={aiSettings.setSkipExtraction}
+              skipInitialLabelling={aiSettings.skipInitialLabelling}
+              setSkipInitialLabelling={aiSettings.setSkipInitialLabelling}
+              skipMergeLabelling={aiSettings.skipMergeLabelling}
+              setSkipMergeLabelling={aiSettings.setSkipMergeLabelling}
+              skipOverview={aiSettings.skipOverview}
+              setSkipOverview={aiSettings.setSkipOverview}
             />
           </Presence>
 

--- a/client-admin/app/create/utils/generateTitle.ts
+++ b/client-admin/app/create/utils/generateTitle.ts
@@ -1,0 +1,45 @@
+import type { useAISettings } from "../hooks/useAISettings";
+import type { useClusterSettings } from "../hooks/useClusterSettings";
+import type { useInputData } from "../hooks/useInputData";
+
+/**
+ * 自動生成される質問タイトル文字列を作成する
+ */
+export function generateDefaultQuestionTitle({
+  inputData,
+  clusterSettings,
+  aiSettings,
+}: {
+  inputData: ReturnType<typeof useInputData>;
+  clusterSettings: ReturnType<typeof useClusterSettings>;
+  aiSettings: ReturnType<typeof useAISettings>;
+}): string {
+  const providerLabel = aiSettings.provider === "none" ? "LLMなし" : `${aiSettings.provider}/${aiSettings.model}`;
+
+  const source =
+    inputData.inputType === "file"
+      ? (inputData.csv?.name ?? "ファイル未指定")
+      : (inputData.spreadsheetUrl.split("/")[5] ?? "シート未指定");
+
+  const col = inputData.selectedCommentColumn || "カラム未選択";
+
+  const clustering = clusterSettings.autoClusterEnabled
+    ? `自動 (${clusterSettings.clusterLv1Max}+${clusterSettings.clusterLv2Max})`
+    : `手動 (${clusterSettings.clusterLv1}+${clusterSettings.clusterLv2})`;
+
+  const skips = [
+    aiSettings.skipExtraction && "抽出スキップ",
+    aiSettings.skipInitialLabelling && "初期ラベルスキップ",
+    aiSettings.skipMergeLabelling && "統合ラベルスキップ",
+    aiSettings.skipOverview && "要約スキップ",
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  const extra =
+    aiSettings.provider !== "none"
+      ? ` (${aiSettings.workers}並列${aiSettings.isEmbeddedAtLocal ? "｜ローカル埋込" : ""})`
+      : "";
+
+  return `[${source}] ${col}列｜${clustering}｜${providerLabel}${extra}${skips ? `｜${skips}` : ""}`;
+}

--- a/client-admin/app/create/utils/validation.ts
+++ b/client-admin/app/create/utils/validation.ts
@@ -49,8 +49,7 @@ export function validateFormValues({
   // 共通チェック
   const commonCheck = [
     isValidId(input),
-    question.length > 0,
-    intro.length > 0,
+    //タイトル、概要は必須から省略時自動設定へ
     clusterLv1 > 0,
     clusterLv2 > 0,
     model.length > 0,

--- a/client/components/report/Analysis.tsx
+++ b/client/components/report/Analysis.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { getClusterNum } from "@/app/utils/cluster-num";
 import {
   DrawerBackdrop,
@@ -19,7 +18,7 @@ import {
   TimelineTitle,
 } from "@/components/ui/timeline";
 import { Tooltip } from "@/components/ui/tooltip";
-import type { Result } from "@/type";
+import type { AutoClusterResult, Result } from "@/type";
 import {
   Box,
   Button,
@@ -40,19 +39,33 @@ import {
   MessageCircleWarningIcon,
   MessagesSquareIcon,
 } from "lucide-react";
-import { useState } from "react";
-
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+const AutoClusterScoreChartClient = dynamic(() => import("./AutoClusterScoreChartClient"), {
+  ssr: false,
+});
 type ReportProps = {
   result: Result;
 };
 
 export function Analysis({ result }: ReportProps) {
+  const [autoClusterData, setAutoClusterData] = useState<AutoClusterResult | null>(null);
   const [selectedData, setSelectedData] = useState<{
     title: string;
     body: string;
   } | null>(null);
   const clusterNum = getClusterNum(result);
   const { open, onToggle } = useDisclosure();
+
+  // Analysis 関数の中にこれを入れる
+  useEffect(() => {
+    if (
+      !result.config.hierarchical_clustering.auto_cluster_enabled ||
+      !result.config.hierarchical_clustering.auto_cluster_result
+    )
+      return;
+    setAutoClusterData(result.config.hierarchical_clustering.auto_cluster_result);
+  }, [result]);
 
   return (
     <Box mx={"auto"} maxW={"750px"} mb={12} cursor={"default"}>
@@ -138,7 +151,9 @@ export function Analysis({ result }: ReportProps) {
                 </TimelineConnector>
                 {p.step === "extraction" && (
                   <TimelineContent>
-                    <TimelineTitle fontWeight={"bold"}>抽出 ({result.config.extraction.model})</TimelineTitle>
+                    <TimelineTitle fontWeight={"bold"}>
+                      抽出 ({result.config.extraction.skip ? "スキップ" : result.config.extraction.model})
+                    </TimelineTitle>
                     <TimelineDescription>
                       コメントデータから意見を抽出するステップです。
                       <br />
@@ -221,13 +236,31 @@ export function Analysis({ result }: ReportProps) {
                       >
                         ソースコード
                       </Button>
+                      {result.config.hierarchical_clustering.auto_cluster_enabled && (
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          onClick={() =>
+                            setSelectedData({
+                              title: "グループ数試行結果",
+                              body: JSON.stringify(result.config.hierarchical_clustering.auto_cluster_result, null, 2),
+                            })
+                          }
+                        >
+                          グループ数試行結果
+                        </Button>
+                      )}
                     </HStack>
                   </TimelineContent>
                 )}
                 {p.step === "hierarchical_initial_labelling" && (
                   <TimelineContent>
                     <TimelineTitle fontWeight={"bold"}>
-                      初期ラベリング ({result.config.hierarchical_initial_labelling.model})
+                      初期ラベリング (
+                      {result.config.hierarchical_initial_labelling.skip
+                        ? "スキップ"
+                        : result.config.hierarchical_initial_labelling.model}
+                      )
                     </TimelineTitle>
                     <TimelineDescription>
                       意見グループ化の結果に対して、各意見グループに適切なタイトル・説明文を生成（ラベリング）するステップです。
@@ -265,7 +298,11 @@ export function Analysis({ result }: ReportProps) {
                 {p.step === "hierarchical_merge_labelling" && (
                   <TimelineContent>
                     <TimelineTitle fontWeight={"bold"}>
-                      統合ラベリング ({result.config.hierarchical_merge_labelling.model})
+                      統合ラベリング (
+                      {result.config.hierarchical_merge_labelling.skip
+                        ? "スキップ"
+                        : result.config.hierarchical_merge_labelling.model}
+                      )
                     </TimelineTitle>
                     <TimelineDescription>
                       意見グループを統合し、統合されたグループのタイトルと説明文を生成（ラベリング）するステップです。
@@ -285,6 +322,7 @@ export function Analysis({ result }: ReportProps) {
                       >
                         ソースコード
                       </Button>
+
                       <Button
                         variant={"outline"}
                         size={"xs"}
@@ -303,7 +341,11 @@ export function Analysis({ result }: ReportProps) {
                 {p.step === "hierarchical_overview" && (
                   <TimelineContent>
                     <TimelineTitle fontWeight={"bold"}>
-                      要約 ({result.config.hierarchical_overview.model})
+                      要約 (
+                      {result.config.hierarchical_overview.skip
+                        ? "スキップ"
+                        : result.config.hierarchical_overview.model}
+                      )
                     </TimelineTitle>
                     <TimelineDescription>
                       意見グループの概要を作成するステップです。
@@ -399,6 +441,21 @@ export function Analysis({ result }: ReportProps) {
             <DrawerTitle>{selectedData?.title}</DrawerTitle>
           </DrawerHeader>
           <DrawerBody fontSize={"xs"}>
+            {/* 🔽 ここにグラフ差し込み条件分岐 */}
+            {(() => {
+              try {
+                return selectedData?.title === "グループ数試行結果" && autoClusterData ? (
+                  <AutoClusterScoreChartClient
+                    data={autoClusterData.results}
+                    bestLv1={autoClusterData.best.lv1.k}
+                    bestLv2={autoClusterData.best.lv2.k}
+                    durationSec={autoClusterData.duration_sec}
+                  />
+                ) : null;
+              } catch (e) {
+                return <Text color="red.400">グラフの描画に失敗しました</Text>;
+              }
+            })()}
             <Box p={5} borderRadius={5} bgColor={"#111"} color={"#fff"} whiteSpace={"pre-wrap"} className={"code"}>
               {selectedData?.body}
             </Box>

--- a/client/components/report/AutoClusterScoreChartClient.tsx
+++ b/client/components/report/AutoClusterScoreChartClient.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Box, Text } from "@chakra-ui/react";
+import Plot from "react-plotly.js";
+
+type DataPoint = {
+  label: string; // 例: "top-3" / "bottom-15"
+  score: number;
+};
+
+type Props = {
+  data: DataPoint[];
+  bestLv1: number;
+  bestLv2: number;
+  durationSec: number;
+};
+
+export default function AutoClusterScoreChartClient({ data, bestLv1, bestLv2, durationSec }: Props) {
+  // x軸ラベルを数値だけに変換 & 上下層分類
+  const simplified = data.map((d) => {
+    const parts = d.label.split("-");
+    const layer = parts[0].toLowerCase(); // ← 小文字化で "lv1", "lv2" に揃える
+    const num = Number(parts[1]);
+    return { ...d, labelNum: num, layer };
+  });
+
+  const lv1Data = simplified.filter((d) => d.layer === "lv1");
+  const lv2Data = simplified.filter((d) => d.layer === "lv2");
+
+  return (
+    <Box w="100%" maxW="750px" mx="auto" mb={8}>
+      <Text fontWeight="bold" mb={2}>
+        意見グループ数ごとの「まとまりの良さ（シルエットスコア）」推移
+      </Text>
+      <Text mb={2}>グループ内の固まりがよく、他のグループと離れていると高い数値になります</Text>
+      <Plot
+        data={[
+          {
+            x: lv1Data.map((d) => d.labelNum),
+            y: lv1Data.map((d) => d.score),
+            type: "scatter",
+            mode: "lines+markers",
+            name: "第一階層",
+            line: { color: "#3182CE" },
+          },
+          {
+            x: lv2Data.map((d) => d.labelNum),
+            y: lv2Data.map((d) => d.score),
+            type: "scatter",
+            mode: "lines+markers",
+            name: "第二階層",
+            line: { color: "#38A169" },
+          },
+        ]}
+        layout={{
+          margin: { t: 30, b: 40, l: 50, r: 30 },
+          xaxis: {
+            title: { text: "グループ数" },
+            tickmode: "linear",
+            dtick: 1,
+          },
+          yaxis: { title: { text: "シルエットスコア" } },
+          height: 300,
+          shapes: [
+            {
+              type: "line",
+              x0: bestLv1,
+              x1: bestLv1,
+              y0: 0,
+              y1: 1,
+              xref: "x",
+              yref: "paper",
+              line: { color: "#3182CE", width: 2, dash: "dot" },
+            },
+            {
+              type: "line",
+              x0: bestLv2,
+              x1: bestLv2,
+              y0: 0,
+              y1: 1,
+              xref: "x",
+              yref: "paper",
+              line: { color: "#38A169", width: 2, dash: "dot" },
+            },
+          ],
+          annotations: [
+            {
+              x: bestLv1,
+              y: 1,
+              xref: "x",
+              yref: "paper",
+              text: "選択",
+              showarrow: false,
+              font: { color: "#3182CE", size: 12 },
+              yanchor: "bottom",
+            },
+            {
+              x: bestLv2,
+              y: 1,
+              xref: "x",
+              yref: "paper",
+              text: "選択",
+              showarrow: false,
+              font: { color: "#38A169", size: 12 },
+              yanchor: "bottom",
+            },
+          ],
+        }}
+        config={{ displayModeBar: false }}
+      />
+      <Text mt={4} fontSize="sm" color="gray.600">
+        試行時間: {durationSec.toFixed(2)} 秒
+      </Text>
+    </Box>
+  );
+}

--- a/server/broadlistening/pipeline/hierarchical_specs.json
+++ b/server/broadlistening/pipeline/hierarchical_specs.json
@@ -22,8 +22,15 @@
         "step": "hierarchical_clustering",
         "filename": "hierarchical_clusters.csv",
         "dependencies": {"params": ["cluster_nums"], "steps": ["embedding"]},
-        "options": {"cluster_nums": [3, 6]}
-    },
+        "options": {
+            "cluster_nums": [3, 6],
+            "auto_cluster_enabled": false,
+            "cluster_lv1_min": 2,
+            "cluster_lv1_max": 10,
+            "cluster_lv2_min": 11,
+            "cluster_lv2_max": 20
+        }
+        },
     {
         "step": "hierarchical_initial_labelling",
         "filename": "hierarchical_initial_labels.csv",

--- a/server/broadlistening/pipeline/hierarchical_utils.py
+++ b/server/broadlistening/pipeline/hierarchical_utils.py
@@ -44,7 +44,7 @@ def validate_config(config):
         if key not in valid_fields and key not in step_names:
             raise Exception(f"Unknown field '{key}' in config")
     for step_spec in specs:
-        valid_options = list(step_spec.get("options", {}).keys())
+        valid_options = list(step_spec.get("options", {}).keys()) + ["skip"]  # ✅ skipを明示的に許可
         if step_spec.get("use_llm"):
             valid_options = valid_options + ["prompt", "model", "prompt_file"]
         for key in config.get(step_spec["step"], {}):

--- a/server/broadlistening/pipeline/services/llm.py
+++ b/server/broadlistening/pipeline/services/llm.py
@@ -3,6 +3,7 @@ import os
 import threading
 
 import openai
+import tiktoken
 from dotenv import load_dotenv
 from openai import AzureOpenAI, OpenAI
 from pydantic import BaseModel
@@ -11,6 +12,8 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 DOTENV_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.env"))
 load_dotenv(DOTENV_PATH)
 
+log_level = os.getenv("LOG_LEVEL", "WARNING").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.WARNING))
 # check env
 use_azure = os.getenv("USE_AZURE", "false").lower()
 
@@ -380,6 +383,7 @@ def request_to_embed(args, model, is_embedded_at_local=False, provider="openai",
     elif provider == "openai":
         logging.info("request_to_openai_embed")
         _validate_model(model)
+        args = preprocess_openai_embed_args(args, model)  # ✅ トークン長チェック＋切り捨て
         client = OpenAI()
         response = client.embeddings.create(input=args, model=model)
         embeds = [item.embedding for item in response.data]
@@ -391,6 +395,24 @@ def request_to_embed(args, model, is_embedded_at_local=False, provider="openai",
         return request_to_local_llm_embed(args, model, address)
     else:
         raise ValueError(f"Unknown provider: {provider}")
+
+
+def preprocess_openai_embed_args(args: list[str], model: str, max_tokens: int = 8000) -> list[str]:
+    # OpenAI埋め込みモデル（例: text-embedding-3-small）に対して、
+    # 各引数をトークン数でチェックし、超過する場合は切り捨て＋警告を行う。
+    tokenizer = tiktoken.encoding_for_model(model)
+    processed_args = []
+
+    for i, text in enumerate(args):
+        tokens = tokenizer.encode(text)
+        if len(tokens) > max_tokens:
+            logging.warning(
+                f"⚠ 入力 arg[{i}] は {len(tokens)} トークンで上限 {max_tokens} を超過。先頭 {max_tokens} トークンに切り捨てます。"
+            )
+            text = tokenizer.decode(tokens[:max_tokens])
+        processed_args.append(text)
+
+    return processed_args
 
 
 def request_to_azure_embed(args, model):
@@ -411,19 +433,30 @@ def request_to_azure_embed(args, model):
 
 __local_emb_model = None
 __local_emb_model_loading_lock = threading.Lock()
+__local_emb_tokenizer = None  # ✅ 追加：トークナイザもキャッシュ
 
 
 def request_to_local_embed(args):
-    global __local_emb_model
-    # memo: モデルを遅延ロード＆キャッシュするために、グローバル変数を使用
+    global __local_emb_model, __local_emb_tokenizer
 
     with __local_emb_model_loading_lock:
-        # memo: スレッドセーフにするためにロックを使用
         if __local_emb_model is None:
             from sentence_transformers import SentenceTransformer
 
             model_name = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
             __local_emb_model = SentenceTransformer(model_name)
+
+        if __local_emb_tokenizer is None:
+            from transformers import AutoTokenizer
+
+            __local_emb_tokenizer = AutoTokenizer.from_pretrained(
+                "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
+            )
+
+    for i, arg in enumerate(args):
+        token_len = len(__local_emb_tokenizer.encode(arg, truncation=True))
+        if token_len > 128:
+            logging.warning(f"arg[{i}] は {token_len} トークン（上限128）で超過。自動的に切り捨てられます。")
 
     result = __local_emb_model.encode(args)
     return result.tolist()

--- a/server/broadlistening/pipeline/steps/embedding.py
+++ b/server/broadlistening/pipeline/steps/embedding.py
@@ -1,23 +1,53 @@
+import os
+
 import pandas as pd
+import tiktoken
 from tqdm import tqdm
 
 from services.llm import request_to_embed
 
 
 def embedding(config):
+    print("LOG_LEVEL =", os.getenv("LOG_LEVEL"))
     model = config["embedding"]["model"]
     is_embedded_at_local = config["is_embedded_at_local"]
-    # print("start embedding")
-    # print(f"embedding model: {model}, is_embedded_at_local: {is_embedded_at_local}")
-
+    provider = config["provider"]
     dataset = config["output_dir"]
     path = f"outputs/{dataset}/embeddings.pkl"
-    arguments = pd.read_csv(f"outputs/{dataset}/args.csv", usecols=["arg-id", "argument"])
+
+    df = pd.read_csv(f"outputs/{dataset}/args.csv", usecols=["arg-id", "argument"])
+    arguments = df["argument"].tolist()
+    arg_ids = df["arg-id"].tolist()
+
+    if not is_embedded_at_local:
+        # https://platform.openai.com/docs/api-reference/embeddings/create
+        # 8192トークン(llm.py）、配列2048次元、合計トークン数300,000を上限を配慮し余裕をもって制限する。
+        tokenizer = tiktoken.encoding_for_model(model)
+        MAX_TOTAL_TOKENS = 200_000
+        MAX_BATCH_SIZE = 1000
+
+        batches = []
+        current_batch = []
+        current_tokens = 0
+
+        for arg in arguments:
+            tokens = len(tokenizer.encode(arg))
+            if (current_tokens + tokens > MAX_TOTAL_TOKENS) or (len(current_batch) >= MAX_BATCH_SIZE):
+                batches.append(current_batch)
+                current_batch = []
+                current_tokens = 0
+            current_batch.append(arg)
+            current_tokens += tokens
+
+        if current_batch:
+            batches.append(current_batch)
+    else:
+        batches = [arguments]
+
     embeddings = []
-    batch_size = 1000
-    for i in tqdm(range(0, len(arguments), batch_size)):
-        args = arguments["argument"].tolist()[i : i + batch_size]
-        embeds = request_to_embed(args, model, is_embedded_at_local, config["provider"])
+    for batch in tqdm(batches, desc="Embedding batches"):
+        embeds = request_to_embed(batch, model, is_embedded_at_local, provider)
         embeddings.extend(embeds)
-    df = pd.DataFrame([{"arg-id": arguments.iloc[i]["arg-id"], "embedding": e} for i, e in enumerate(embeddings)])
-    df.to_pickle(path)
+
+    out_df = pd.DataFrame([{"arg-id": arg_ids[i], "embedding": embeddings[i]} for i in range(len(embeddings))])
+    out_df.to_pickle(path)

--- a/server/broadlistening/pipeline/steps/extraction.py
+++ b/server/broadlistening/pipeline/steps/extraction.py
@@ -32,7 +32,7 @@ def extraction(config):
     workers = config["extraction"]["workers"]
     limit = config["extraction"]["limit"]
     property_columns = config["extraction"]["properties"]
-
+    skip_extraction = config["extraction"].get("skip", False)
     if "provider" not in config:
         raise RuntimeError("provider is not set")
     provider = config["provider"]
@@ -44,42 +44,61 @@ def extraction(config):
     comments = pd.read_csv(
         f"inputs/{config['input']}.csv", usecols=["comment-id", "comment-body"] + config["extraction"]["properties"]
     )
-    comment_ids = (comments["comment-id"].values)[:limit]
+
+    # ✅ 空コメントを除外（この段階ではまだ index 化してないのでOK）
+    comments = comments[comments["comment-body"].notna() & (comments["comment-body"].str.strip() != "")]
     comments.set_index("comment-id", inplace=True)
+    comment_ids = comments.index.values[:limit]
     results = pd.DataFrame()
     update_progress(config, total=len(comment_ids))
 
     argument_map = {}
     relation_rows = []
 
-    for i in tqdm(range(0, len(comment_ids), workers)):
-        batch = comment_ids[i : i + workers]
-        batch_inputs = [comments.loc[id]["comment-body"] for id in batch]
-        batch_results = extract_batch(
-            batch_inputs, prompt, model, workers, provider, config.get("local_llm_address"), config
-        )
-
-        for comment_id, extracted_args in zip(batch, batch_results, strict=False):
-            for j, arg in enumerate(extracted_args):
-                if arg not in argument_map:
-                    # argumentテーブルに追加
-                    arg_id = f"A{comment_id}_{j}"
-                    argument = arg
-                    argument_map[arg] = {
-                        "arg-id": arg_id,
-                        "argument": argument,
-                    }
-                else:
-                    arg_id = argument_map[arg]["arg-id"]
-
-                # relationテーブルにcommentとargの関係を追加
-                relation_row = {
+    if skip_extraction:
+        print("⏩ 抽出ステップをスキップします（skip_extraction が有効）")
+        for _, comment_id in enumerate(comment_ids):
+            comment_body = comments.loc[comment_id]["comment-body"]
+            arg_id = f"A{comment_id}_0"
+            argument_map[comment_body] = {
+                "arg-id": arg_id,
+                "argument": comment_body,
+            }
+            relation_rows.append(
+                {
                     "arg-id": arg_id,
                     "comment-id": comment_id,
                 }
-                relation_rows.append(relation_row)
+            )
+            update_progress(config, incr=1)
+    else:
+        for i in tqdm(range(0, len(comment_ids), workers)):
+            batch = comment_ids[i : i + workers]
+            batch_inputs = [comments.loc[id]["comment-body"] for id in batch]
+            batch_results = extract_batch(
+                batch_inputs, prompt, model, workers, provider, config.get("local_llm_address"), config
+            )
 
-        update_progress(config, incr=len(batch))
+            for comment_id, extracted_args in zip(batch, batch_results, strict=False):
+                for j, arg in enumerate(extracted_args):
+                    if arg not in argument_map:
+                        # argumentテーブルに追加
+                        arg_id = f"A{comment_id}_{j}"
+                        argument_map[arg] = {
+                            "arg-id": arg_id,
+                            "argument": arg,
+                        }
+                    else:
+                        arg_id = argument_map[arg]["arg-id"]
+
+                    # relationテーブルにcommentとargの関係を追加
+                    relation_row = {
+                        "arg-id": arg_id,
+                        "comment-id": comment_id,
+                    }
+                    relation_rows.append(relation_row)
+
+            update_progress(config, incr=len(batch))
 
     # DataFrame化
     results = pd.DataFrame(argument_map.values())

--- a/server/broadlistening/pipeline/steps/generate_html.py
+++ b/server/broadlistening/pipeline/steps/generate_html.py
@@ -1,0 +1,140 @@
+import json
+import os
+
+import pandas as pd
+import plotly.express as px
+
+# 🔧 パスの設定
+DATA_DIR = r"D:\myproject\kouchou-ai\server\broadlistening\pipeline\outputs\52c5472d-ad28-4d2b-b420-aa30e50dadbe"
+RESULT_CSV = os.path.join(DATA_DIR, "bertopic_result.csv")
+LABEL_JSON = os.path.join(DATA_DIR, "cluster_labels.json")
+HTML_OUT = os.path.join(DATA_DIR, "cluster_overview.html")
+
+# 📄 データ読み込み
+result_df = pd.read_csv(RESULT_CSV)
+with open(LABEL_JSON, encoding="utf-8") as f:
+    label_dict = json.load(f)
+
+# 🛠 確信度列がなければ仮で100%に設定
+if "probability" not in result_df.columns:
+    result_df["probability"] = 1.0
+
+# 💡 クラスタID列
+result_df["cluster_id"] = result_df["hdbscan-cluster-id"]
+result_df["cluster_str"] = result_df["cluster_id"].astype(str)
+
+# 📊 クラスタ要約情報の抽出
+cluster_summary = []
+grouped = result_df.groupby("cluster_str")
+for cluster_id, group in grouped:
+    cluster_info = {
+        "cluster_id": cluster_id,
+        "size": len(group),
+        "keywords": group["topic-representative-words"].iloc[0]
+        if "topic-representative-words" in group.columns
+        else "",
+        "representative": label_dict.get(cluster_id, {}).get(
+            "representative", group.loc[group["probability"].idxmax()]["argument"]
+        ),
+    }
+    if cluster_id == "-1":
+        cluster_info["representative"] = "その他少数意見"
+        cluster_info["keywords"] = ""
+    cluster_summary.append(cluster_info)
+
+# 📋 クラスタ概要テーブルHTML
+cluster_table_html = (
+    "<table border='1'><tr><th>クラスタID</th><th>代表語</th><th>件数</th><th>簡易ラベル（キーワード）</th></tr>"
+)
+for c in cluster_summary:
+    cluster_table_html += (
+        f"<tr><td>{c['cluster_id']}</td><td>{c['representative']}</td><td>{c['size']}</td><td>{c['keywords']}</td></tr>"
+    )
+cluster_table_html += "</table>"
+
+# 🌐 散布図を生成（plotly）
+scatter_fig = px.scatter(
+    result_df,
+    x="x",
+    y="y",
+    color="cluster_str",
+    hover_data=["arg-id", "argument", "probability"],
+    title="UMAP + HDBSCAN クラスタリング散布図",
+    width=1800,
+    height=1000,
+)
+scatter_html = scatter_fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+# 📝 各クラスタの本文一覧（確信度順）＋ クラスタ情報付きヘッダ
+cluster_detail_html = ""
+for c in cluster_summary:
+    cluster_id = c["cluster_id"]
+    representative = c["representative"]
+    size = c["size"]
+    keywords = c["keywords"]
+
+    cluster_detail_html += (
+        f"<h3>クラスタ {cluster_id} | 代表語: {representative} | 件数: {size} | キーワード: {keywords}</h3><ul>"
+    )
+
+    group = grouped.get_group(str(cluster_id))
+    group_sorted = group.sort_values(by="probability", ascending=False)
+
+    for _, row in group_sorted.iterrows():
+        score = f"{int(row['probability'] * 100)}%" if row["cluster_id"] != -1 else "--"
+        cluster_detail_html += f"<li>[{score}] {row['argument']}</li>"
+    cluster_detail_html += "</ul>"
+
+# 📄 HTMLヘッダー＋CSS（吹き出しの切れ防止用）
+html_header = """
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>クラスタ概要</title>
+    <style>
+        body {
+            max-width: none;
+            margin: 40px;
+            font-family: sans-serif;
+        }
+        .hoverlayer .hovertext text {
+            white-space: pre-wrap !important;
+            overflow-wrap: break-word !important;
+            max-width: 600px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        td, th {
+            padding: 6px 10px;
+        }
+        ul {
+            padding-left: 1em;
+        }
+    </style>
+</head>
+<body>
+"""
+
+# 📄 全体HTML組み立て
+full_html = f"""
+{html_header}
+    <h1>クラスタ概要（表形式）</h1>
+    {cluster_table_html}
+
+    <h2>クラスタ散布図</h2>
+    {scatter_html}
+
+    <h2>クラスタごとの意見一覧</h2>
+    {cluster_detail_html}
+</body>
+</html>
+"""
+
+# 💾 HTML保存
+with open(HTML_OUT, "w", encoding="utf-8") as f:
+    f.write(full_html)
+
+print("✅ クラスタ概要HTMLを生成しました:", HTML_OUT)

--- a/server/broadlistening/pipeline/steps/hdbscan_clustering.py
+++ b/server/broadlistening/pipeline/steps/hdbscan_clustering.py
@@ -1,0 +1,126 @@
+import json
+import os
+
+import nltk
+import numpy as np
+import pandas as pd
+import stopwordsiso as sw
+from bertopic import BERTopic
+from hdbscan import HDBSCAN
+from janome.tokenizer import Tokenizer
+from sklearn.feature_extraction.text import CountVectorizer
+from umap import UMAP
+
+nltk.download("stopwords")
+
+
+# ✅ Janomeベースの日本語トークナイザー
+def japanese_tokenizer(text):
+    t = Tokenizer()
+    tokens = [
+        token.base_form
+        for token in t.tokenize(text)
+        if token.part_of_speech.split(",")[0] in ["名詞", "動詞", "形容詞"]
+    ]
+    return tokens
+
+
+def run_clustering():
+    # 📂 入力・出力パス設定
+    DATA_DIR = r"D:\myproject\kouchou-ai\server\broadlistening\pipeline\outputs\52c5472d-ad28-4d2b-b420-aa30e50dadbe"
+    ARGS_PATH = os.path.join(DATA_DIR, "args.csv")
+    EMBEDDINGS_PATH = os.path.join(DATA_DIR, "embeddings.pkl")
+    OUTPUT_PATH = os.path.join(DATA_DIR, "bertopic_result.csv")
+    TREE_OUTPUT_PATH = os.path.join(DATA_DIR, "hdbscan_condensed_tree.csv")
+    LINKAGE_PATH = os.path.join(DATA_DIR, "hdbscan_linkage_matrix.npy")
+
+    # 📄 データ読み込み
+    args_df = pd.read_csv(ARGS_PATH)
+    embeddings_df = pd.read_pickle(EMBEDDINGS_PATH)
+    merged_df = pd.merge(args_df, embeddings_df, on="arg-id", how="inner")
+
+    documents = merged_df["argument"].tolist()
+    embeddings = np.vstack(merged_df["embedding"].values)
+
+    # 🔹 クラスタリング用にUMAPで50次元へ次元削減
+    umap_model_50d = UMAP(n_components=50, random_state=42)
+    embeddings_50d = umap_model_50d.fit_transform(embeddings)
+
+    # 🔸 可視化用にUMAPで2次元へ圧縮
+    umap_model_2d = UMAP(n_components=2, random_state=42)
+    coords_2d = umap_model_2d.fit_transform(embeddings)
+
+    # 🌲 HDBSCANクラスタリング（BERTopicに渡す用）
+    hdbscan_model = HDBSCAN(min_cluster_size=3, min_samples=1, prediction_data=True)
+
+    # 🛑 ストップワード（stopwords-iso + カスタム）
+    stopwords = list(set(sw.stopwords("ja")) | {"こう", "よく", "とる"})
+
+    # 🔠 CountVectorizer（日本語トークン＆ストップワード）
+    vectorizer_model = CountVectorizer(
+        tokenizer=japanese_tokenizer,
+        stop_words=stopwords,
+    )
+
+    # 🧠 BERTopic：クラスタリングと可視化用モデルの両方を渡す
+    topic_model = BERTopic(
+        language="japanese",
+        hdbscan_model=hdbscan_model,
+        umap_model=umap_model_2d,  # ← 可視化用
+        vectorizer_model=vectorizer_model,
+        calculate_probabilities=False,
+        verbose=False,
+    )
+
+    # 🧩 トピック抽出（ここでHDBSCANも内部で使われる）
+    topics, _ = topic_model.fit_transform(documents, embeddings_50d)
+    topic_reprs = topic_model.get_topics()
+    labels = topic_model.get_document_info(documents)["Topic"]
+    probabilities = topic_model.hdbscan_model.probabilities_
+
+    # トピック代表語を抽出
+    topic_words = [
+        ", ".join([word for word, _ in topic_reprs.get(topic, [])]) if topic in topic_reprs else "" for topic in topics
+    ]
+
+    # 💾 結果保存
+    result_df = pd.DataFrame(
+        {
+            "arg-id": merged_df["arg-id"],
+            "argument": documents,
+            "x": coords_2d[:, 0],
+            "y": coords_2d[:, 1],
+            "hdbscan-cluster-id": labels,
+            "probability": probabilities,  # ← 追加
+            "topic-representative-words": topic_words,
+        }
+    )
+    result_df.to_csv(OUTPUT_PATH, index=False)
+
+    # 🌟 cluster_labels.json を生成
+    LABEL_JSON_PATH = os.path.join(DATA_DIR, "cluster_labels.json")
+    cluster_labels = {}
+    for topic_id, words in topic_reprs.items():
+        if not words:
+            continue
+        representative = words[0][0]
+        keywords = [w for w, _ in words]
+        cluster_labels[str(topic_id)] = {
+            "representative": representative,
+            "keywords": keywords,
+        }
+    with open(LABEL_JSON_PATH, "w", encoding="utf-8") as f:
+        json.dump(cluster_labels, f, ensure_ascii=False, indent=2)
+
+    # condensed tree / linkage 出力
+    hdbscan_fitted = topic_model.hdbscan_model
+    hdbscan_fitted.condensed_tree_.to_pandas().to_csv(TREE_OUTPUT_PATH, index=False)
+    np.save(LINKAGE_PATH, hdbscan_fitted.single_linkage_tree_.to_numpy())
+
+    return result_df.head()
+
+
+if __name__ == "__main__":
+    preview = run_clustering()
+    print("✅ clustering preview:")
+    print(preview)

--- a/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
@@ -131,7 +131,7 @@ def create_custom_intro(config):
     print(f"Args count: {args_count}")
 
     base_custom_intro = """{intro}
-分析対象となったデータの件数は{processed_num}件で、これらのデータに対してOpenAI APIを用いて{args_count}件の意見（議論）を抽出し、クラスタリングを行った。
+分析対象となったデータの件数は{processed_num}件で、これらのデータから{args_count}件の意見（議論）を抽出し、グループ化を行った。
 """
 
     intro = config["intro"]

--- a/server/broadlistening/pipeline/steps/hierarchical_clustering.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_clustering.py
@@ -1,11 +1,16 @@
-"""Cluster the arguments using UMAP + HDBSCAN and GPT-4."""
-
+import logging
+import time
+from datetime import datetime
 from importlib import import_module
 
 import numpy as np
 import pandas as pd
 import scipy.cluster.hierarchy as sch
+from hierarchical_utils import update_status
 from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+
+logging.getLogger("numba").setLevel(logging.WARNING)
 
 
 def hierarchical_clustering(config):
@@ -16,15 +21,12 @@ def hierarchical_clustering(config):
     arguments_df = pd.read_csv(f"outputs/{dataset}/args.csv", usecols=["arg-id", "argument"])
     embeddings_df = pd.read_pickle(f"outputs/{dataset}/embeddings.pkl")
     embeddings_array = np.asarray(embeddings_df["embedding"].values.tolist())
-    cluster_nums = config["hierarchical_clustering"]["cluster_nums"]
 
     n_samples = embeddings_array.shape[0]
-    # デフォルト設定は15
     default_n_neighbors = 15
-
     # テスト等サンプルが少なすぎる場合、n_neighborsの設定値を下げる
     if n_samples <= default_n_neighbors:
-        n_neighbors = max(2, n_samples - 1)  # 最低2以上
+        n_neighbors = max(2, n_samples - 1)
     else:
         n_neighbors = default_n_neighbors
 
@@ -32,12 +34,92 @@ def hierarchical_clustering(config):
     # TODO 詳細エラーメッセージを加える
     # 以下のエラーの場合、おそらく元の意見件数が少なすぎることが原因
     # TypeError: Cannot use scipy.linalg.eigh for sparse A with k >= N. Use scipy.linalg.eigh(A.toarray()) or reduce k.
+
     umap_embeds = umap_model.fit_transform(embeddings_array)
+    # ✅ 自動クラスタ設定の場合
+    clustering_config = config.get("hierarchical_clustering", {})
+    if clustering_config.get("auto_cluster_enabled", False):
+        lv1_min = clustering_config.get("cluster_lv1_min", 2)
+        lv1_max = clustering_config.get("cluster_lv1_max", 20)
+        lv2_min = clustering_config.get("cluster_lv2_min", lv1_max + 1)
+        lv2_max = clustering_config.get("cluster_lv2_max", 100)
+
+        n_samples = umap_embeds.shape[0]
+        max_clusters = max(2, n_samples - 1)
+
+        # 上限補正
+        lv1_max = min(lv1_max, max_clusters)
+        lv2_max = min(lv2_max, max_clusters)
+
+        # 下限補正
+        lv1_min = max(2, min(lv1_min, lv1_max))
+        lv2_min = max(lv1_max + 1, min(lv2_min, lv2_max))
+
+        silhouette_results = []
+        best_lv1_score, best_lv1 = -1, None
+        best_lv2_score, best_lv2 = -1, None
+
+        start = time.time()
+
+        for k in range(lv1_min, lv1_max + 1):
+            try:
+                labels = KMeans(n_clusters=k, random_state=42).fit_predict(umap_embeds)
+                score = silhouette_score(umap_embeds, labels)
+                silhouette_results.append((f"lv1-{k}", score))
+                if score > best_lv1_score:
+                    best_lv1_score, best_lv1 = score, k
+            except ValueError as e:
+                print(f"[auto-cluster] silhouette_score error for lv1-{k}: {e}")
+
+        for k in range(lv2_min, lv2_max + 1):
+            try:
+                labels = KMeans(n_clusters=k, random_state=42).fit_predict(umap_embeds)
+                score = silhouette_score(umap_embeds, labels)
+                silhouette_results.append((f"lv2-{k}", score))
+                if score > best_lv2_score:
+                    best_lv2_score, best_lv2 = score, k
+            except ValueError as e:
+                print(f"[auto-cluster] silhouette_score error for lv2-{k}: {e}")
+
+        duration_sec = round(time.time() - start, 2)
+
+        structured_result = {
+            "timestamp": datetime.now().isoformat(),
+            "lv1_range": [int(lv1_min), int(lv1_max)],
+            "lv2_range": [int(lv2_min), int(lv2_max)],
+            "best": {
+                "lv1": {"k": int(best_lv1), "score": float(round(best_lv1_score, 6))},
+                "lv2": {"k": int(best_lv2), "score": float(round(best_lv2_score, 6))},
+            },
+            "duration_sec": float(duration_sec),
+            "results": [{"label": label, "score": float(round(score, 6))} for label, score in silhouette_results],
+        }
+
+        # 人間向けの .txt 出力も維持
+        lines = ["🔎 クラスタリング評価結果 (Silhouette Score)"]
+        for r in structured_result["results"]:
+            lines.append(f"{r['label']:>10}: {r['score']:.6f}")
+        lines.append("\n✅ 最適クラスタ数:")
+        lines.append(f" - best_lv1: {best_lv1} (score={best_lv1_score:.6f})")
+        lines.append(f" - best_lv2: {best_lv2} (score={best_lv2_score:.6f})")
+        with open(f"outputs/{dataset}/auto_cluster_result.txt", "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        # ✅ 保存
+        clustering_config["auto_cluster_result"] = structured_result
+        cluster_nums = [best_lv1, best_lv2]
+        clustering_config["cluster_nums"] = cluster_nums
+
+        update_status(config, {})
+    else:
+        # 通常モード
+        cluster_nums = config["hierarchical_clustering"]["cluster_nums"]
 
     cluster_results = hierarchical_clustering_embeddings(
         umap_embeds=umap_embeds,
         cluster_nums=cluster_nums,
     )
+
     result_df = pd.DataFrame(
         {
             "arg-id": arguments_df["arg-id"],
@@ -46,7 +128,6 @@ def hierarchical_clustering(config):
             "y": umap_embeds[:, 1],
         }
     )
-
     for cluster_level, final_labels in enumerate(cluster_results.values(), start=1):
         result_df[f"cluster-level-{cluster_level}-id"] = [f"{cluster_level}_{label}" for label in final_labels]
 

--- a/server/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
@@ -36,6 +36,8 @@ def hierarchical_initial_labelling(config: dict) -> None:
 
     cluster_id_columns = [col for col in clusters_argument_df.columns if col.startswith("cluster-level-")]
     initial_cluster_id_column = cluster_id_columns[-1]
+
+    # スキップしない通常処理
     sampling_num = config["hierarchical_initial_labelling"]["sampling_num"]
     initial_labelling_prompt = config["hierarchical_initial_labelling"]["prompt"]
     model = config["hierarchical_initial_labelling"]["model"]
@@ -148,6 +150,13 @@ def process_initial_labelling(
     Returns:
         クラスタのラベリング結果
     """
+    # ✅ スキップ対応
+    if config["hierarchical_initial_labelling"].get("skip", False):
+        print(f"⏩ 初期ラベリングをスキップします。{cluster_id}")
+        return LabellingResult(
+            cluster_id=cluster_id, label=f"クラスタ {cluster_id}", description="（説明は省略されています）"
+        )
+
     cluster_data = df[df[target_column] == cluster_id]
     sampling_num = min(sampling_num, len(cluster_data))
     cluster = cluster_data.sample(sampling_num)

--- a/server/broadlistening/pipeline/steps/hierarchical_overview.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_overview.py
@@ -17,6 +17,13 @@ def hierarchical_overview(config):
     dataset = config["output_dir"]
     path = f"outputs/{dataset}/hierarchical_overview.txt"
 
+    # ✅ スキップ時処理
+    if config["hierarchical_overview"].get("skip", False):
+        print("⏩ 概要生成（overview）をスキップします。")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("（説明は省略されています）")
+        return
+
     hierarchical_label_df = pd.read_csv(f"outputs/{dataset}/hierarchical_merge_labels.csv")
 
     prompt = config["hierarchical_overview"]["prompt"]

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -38,6 +38,17 @@ class ReportInput(SchemaBaseModel):
 
     # NOTE: team-mirai feature
     enable_source_link: bool = False  # ソースリンク機能を有効にするかどうか。有効にする場合はtrue
+    skip_extraction: bool = False  # 意見抽出スキップ
+    skip_initial_labelling: bool = False  # 初期ラベリングスキップ
+    skip_merge_labelling: bool = False  # 統合ラベリングスキップ
+    skip_overview: bool = False  # 要約プロンプトスキップ
+
+    auto_cluster_enabled: bool = False  # 自動クラスタ数設定
+    clusterLv1_min: int | None = None  # 自動クラスタ範囲（上位層最小）
+    clusterLv1_max: int | None = None  # 自動クラスタ範囲（上位層最大）
+    clusterLv2_min: int | None = None  # 自動クラスタ範囲（下位層最小）
+    clusterLv2_max: int | None = None  # 自動クラスタ範囲（下位層最大）
+
 
 
 class ReportVisibilityUpdate(SchemaBaseModel):

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -32,21 +32,32 @@ def _build_config(report_input: ReportInput) -> dict[str, Any]:
             "prompt": report_input.prompt.extraction,
             "workers": report_input.workers,
             "limit": comment_num,
+            "skip": report_input.skip_extraction,
         },
         "hierarchical_clustering": {
             "cluster_nums": report_input.cluster,
+            "auto_cluster_enabled": report_input.auto_cluster_enabled,
+            "cluster_lv1_min": report_input.clusterLv1_min,
+            "cluster_lv1_max": report_input.clusterLv1_max,
+            "cluster_lv2_min": report_input.clusterLv2_min,
+            "cluster_lv2_max": report_input.clusterLv2_max,
         },
         "hierarchical_initial_labelling": {
             "prompt": report_input.prompt.initial_labelling,
             "sampling_num": 30,
             "workers": report_input.workers,
+            "skip": report_input.skip_initial_labelling,
         },
         "hierarchical_merge_labelling": {
             "prompt": report_input.prompt.merge_labelling,
             "sampling_num": 30,
             "workers": report_input.workers,
+            "skip": report_input.skip_merge_labelling,
         },
-        "hierarchical_overview": {"prompt": report_input.prompt.overview},
+        "hierarchical_overview": {
+            "prompt": report_input.prompt.overview,
+            "skip": report_input.skip_overview,
+        },
         "hierarchical_aggregation": {
             "sampling_num": report_input.workers,
         },


### PR DESCRIPTION
# 変更の概要

1. グループ数を自動で決定するを追加
2. AIプロバイダーに「使用しない」を追加。（LLM全スキップ）
3. 抽出、初期、統合、要約にスキップを追加
4. タイトル、概要の必須を外し、省略時タイトル自動補完
5. 分析の概要の説明からOpen AIを削除（LLMには触れない）
6. 分析手順でスキップした手順ではモデル表示はスキップ
7. グループ数を自動で決定の場合にグループ数試行結果ボタン・画面表示

# スクリーンショット
- https://github.com/digitaldemocracy2030/kouchou-ai/pull/567
にはってたやつ

# 変更の背景
- Issue対応

# 関連Issue
[自動クラスタ、スキップ、省略タイトル対応](https://github.com/take365/kouchou-ai/issues/6)

# 動作確認の結果


# CLAへの同意
- [X ] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。