### PR TITLE
オールインワンな静的html（シンプル版）対応 #9

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -610,6 +610,25 @@ function ReportCard({
                 </Portal>
               </Popover.Root>
             )}
+            {/* ✅ 軽量HTMLレポートボタン（常設） */}
+            {report.status === "ready" && (
+              <Button
+                variant="ghost"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(`${getApiBaseUrl()}/admin/reports/${report.slug}/simple-html`, "_blank");
+                }}
+              >
+                <Tooltip content="１枚完結のHTMLレポートを表示" openDelay={0} closeDelay={0}>
+                  <Flex align="center" gap={1}>
+                    <Icon>
+                      <ExternalLinkIcon />
+                    </Icon>
+                    <Text fontSize="sm">シンプル版</Text>
+                  </Flex>
+                </Tooltip>
+              </Button>
+            )}
             {report.status === "ready" && (
               <Box
                 onClick={(e) => e.stopPropagation()}

--- a/server/broadlistening/pipeline/hierarchical_main.py
+++ b/server/broadlistening/pipeline/hierarchical_main.py
@@ -4,6 +4,7 @@ import sys
 from hierarchical_utils import initialization, run_step, termination
 from steps.embedding import embedding
 from steps.extraction import extraction
+from steps.generate_simple_html import generate_simple_html
 from steps.hierarchical_aggregation import hierarchical_aggregation
 from steps.hierarchical_clustering import hierarchical_clustering
 from steps.hierarchical_initial_labelling import hierarchical_initial_labelling
@@ -65,6 +66,11 @@ def main():
         run_step("hierarchical_merge_labelling", hierarchical_merge_labelling, config)
         run_step("hierarchical_overview", hierarchical_overview, config)
         run_step("hierarchical_aggregation", hierarchical_aggregation, config)
+        try:
+            print("[INFO] Generating simple HTML report...")
+            generate_simple_html(config)
+        except Exception as e:
+            print(f"[WARN] Failed to generate simple HTML report: {e}")
         run_step("hierarchical_visualization", hierarchical_visualization, config)
 
         termination(config)

--- a/server/broadlistening/pipeline/steps/generate_simple_html.py
+++ b/server/broadlistening/pipeline/steps/generate_simple_html.py
@@ -1,0 +1,89 @@
+import colorsys
+import json
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def load_json_with_fallback(path: Path):
+    """UTF-8優先 → SJISフォールバックでJSON読み込み"""
+    if not path.exists():
+        print(f"⚠️ Missing: {path}")
+        return {}
+    try:
+        with open(path, encoding='utf-8') as f:
+            return json.load(f)
+    except UnicodeDecodeError:
+        with open(path, encoding='shift_jis') as f:
+            return json.load(f)
+
+
+def generate_simple_html(config):
+    output_dir = config["output_dir"]
+    base_path = Path(f"outputs/{output_dir}")
+    input_path = base_path / "hierarchical_result.json"
+    output_path = base_path / "simple_report.html"
+    overview_path = base_path / "hierarchical_overview.txt"
+    template_dir = Path("templates")
+    template_name = "simple_report_template.html"
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"⛔ {input_path} が見つかりません")
+
+    result = load_json_with_fallback(input_path)
+    hierarchical_overview = overview_path.read_text(encoding="utf-8") if overview_path.exists() else ""
+
+    # クラスタ構造を再構築
+    clusters = result["clusters"]
+    cluster_children = {}
+    for c in clusters:
+        parent = c.get("parent")
+        if parent:
+            cluster_children.setdefault(parent, []).append(c)
+
+    def build_tree(cluster):
+        cid = cluster["id"]
+        cluster["children"] = [build_tree(child) for child in cluster_children.get(cid, [])]
+        return cluster
+
+    # 上位層クラスタのみ対象
+    level1_clusters = [c for c in clusters if c.get("level") == 1]
+    cluster_tree = [build_tree(c) for c in level1_clusters]
+
+    # 色マップ（Lv1クラスタのみ）
+    color_map = {}
+    for i, c in enumerate(level1_clusters):
+        hue = (i * 0.14) % 1.0
+        rgb = colorsys.hsv_to_rgb(hue, 0.6, 0.7)
+        hex_color = f'#{int(rgb[0] * 255):02x}{int(rgb[1] * 255):02x}{int(rgb[2] * 255):02x}'
+        color_map[c["id"]] = hex_color
+
+    # 上位クラスタごとに属する arguments を収集（Lv2経由でない）
+    cluster_args_map = {}
+    for c in level1_clusters:
+        cluster_args_map[c["id"]] = [
+            a for a in result["arguments"]
+            if c["id"] in a.get("cluster_ids", [])
+        ]
+
+    env = Environment(loader=FileSystemLoader(str(template_dir)))
+    env.tests["search"] = lambda value, sub: sub in value
+    template = env.get_template(template_name)
+
+    html = template.render(
+        result=result,
+        cluster_tree=cluster_tree,
+        hierarchical_overview=hierarchical_overview,
+        color_map=color_map,
+        cluster_args_map=cluster_args_map  # JavaScriptで活用する場合にも利用可能
+    )
+    output_path.write_text(html, encoding="utf-8")
+    print(f"✅ 出力完了: {output_path}")
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 2:
+        print("Usage: python generate_simple_html.py [dataset-slug]")
+        sys.exit(1)
+    generate_simple_html({"output_dir": sys.argv[1]})

--- a/server/broadlistening/pipeline/templates/simple_report_template.html
+++ b/server/broadlistening/pipeline/templates/simple_report_template.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>{{ result.config.question }}</title>
+    <script src="https://cdn.plot.ly/plotly-2.26.0.min.js"></script>
+    <style>
+        body {
+            font-family: sans-serif;
+            margin: 20px;
+            max-width: 1200px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        h1 {
+            color: #2577B1;
+        }
+
+        .intro,
+        .overview {
+            margin-bottom: 1em;
+            white-space: pre-wrap;
+        }
+
+        .group {
+            border: 1px solid #ccc;
+            margin: 5px 0;
+            padding: 5px 10px;
+        }
+
+        .group-header {
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background-color: #f7f7f7;
+            padding: 5px;
+        }
+
+        .group-header .toggle {
+            font-weight: bold;
+            margin-right: 10px;
+            user-select: none;
+        }
+
+        .group-header .title {
+            flex: 1;
+        }
+
+        .group-header .stats {
+            font-size: 0.9em;
+            color: #555;
+            margin-left: 10px;
+        }
+
+        .summary {
+            font-size: 0.9em;
+            color: #333;
+            margin-left: 20px;
+        }
+
+        .group-children,
+        .arguments {
+            margin-left: 20px;
+            border-left: 1px dashed #ccc;
+            padding-left: 10px;
+        }
+
+        .argument {
+            margin: 5px 0;
+            padding: 3px;
+            background-color: #eef;
+        }
+
+        #toggleAll,
+        #toggleLabels {
+            margin: 10px 5px 15px 0;
+            background-color: #3182ce;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            padding: 8px 12px;
+            font-size: 1em;
+            cursor: pointer;
+        }
+
+        #toggleAll:hover,
+        #toggleLabels:hover {
+            background-color: #2a69ac;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>{{ result.config.question }}</h1>
+    <div class="overview">{{ hierarchical_overview }}</div>
+
+    <div class="chart-container" id="scatterChart"></div>
+
+    <h2>意見グループ一覧</h2>
+    <button id="toggleAll" onclick="toggleAllGroups()">すべて展開</button>
+    <button id="toggleLabels" onclick="toggleLabels()">ラベル非表示</button>
+    <div id="groupContainer">
+        {% macro render_group(group, parent_color='') %}
+        {%- if group.level == 1 and color_map[group.id] is defined -%}
+        {%- set my_color = color_map[group.id] -%}
+        {%- else -%}
+        {%- set my_color = parent_color -%}
+        {%- endif %}
+
+        <div class="group" data-group-id="{{ group.id }}">
+            <div class="group-header" onclick="toggleThisGroup(this)" style="color: {{ my_color }};">
+                <span class="toggle">[+]</span>
+                <span class="title">{{ group.label }}</span>
+                <span class="stats">{{ group.value }}件</span>
+            </div>
+            <div class="summary">{{ group.takeaway }}</div>
+
+            {% if group.children and group.children | length > 0 %}
+            <div class="group-children" style="display: none;">
+                {% for child in group.children %}
+                {{ render_group(child, my_color) }}
+                {% endfor %}
+            </div>
+            {% else %}
+            {% set group_args = result.arguments | selectattr("cluster_ids", "search", group.id) | list %}
+            {% if group_args | length > 0 %}
+            <div class="arguments" style="display: none;">
+                {% for arg in group_args %}
+                <div class="argument">{{ arg.argument }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% endif %}
+        </div>
+        {% endmacro %}
+
+        {% for group in cluster_tree %}
+        {{ render_group(group) }}
+        {% endfor %}
+
+        <div class="intro">{{ result.config.intro }}</div>
+    </div>
+
+    <script>
+        const result = {{ result | tojson(indent = 2) }};
+        const color_map = {{ color_map | tojson(indent = 2) }};
+        const clusters = result.clusters.filter(c => c.level === 1);
+        const args = result.arguments;
+
+        let labelVisible = true;
+
+        const clusterLabels = clusters.map((cluster, idx) => {
+            const clusterArgs = args.filter(arg => arg.cluster_ids.includes(cluster.id));
+            if (clusterArgs.length === 0) return null;
+            const centerX = clusterArgs.map(arg => arg.x).reduce((a, b) => a + b, 0) / clusterArgs.length;
+            const centerY = clusterArgs.map(arg => arg.y).reduce((a, b) => a + b, 0) / clusterArgs.length;
+            const bgColor = color_map[cluster.id] || `hsl(${(idx * 40) % 360},70%,60%)`;
+            return {
+                x: centerX,
+                y: centerY,
+                text: cluster.label,
+                showarrow: false,
+                font: { size: 13, color: "white" },
+                align: "center",
+                bgcolor: bgColor,
+                opacity: 0.7,
+                borderpad: 4
+            };
+        }).filter(Boolean);
+
+        function toggleLabels() {
+            labelVisible = !labelVisible;
+            const newAnnotations = clusterLabels.map(label => ({ ...label, visible: labelVisible }));
+            Plotly.relayout("scatterChart", { annotations: newAnnotations });
+            const btn = document.getElementById("toggleLabels");
+            btn.textContent = labelVisible ? "ラベル非表示" : "ラベル表示";
+        }
+
+        const scatterData = clusters.map((cluster, idx) => {
+            const clusterArgs = args.filter(arg => arg.cluster_ids.includes(cluster.id));
+            const x = clusterArgs.map(arg => arg.x);
+            const y = clusterArgs.map(arg => arg.y);
+            const color = color_map[cluster.id] || `hsl(${(idx * 40) % 360},70%,60%)`;
+            return {
+                x: x,
+                y: y,
+                mode: "markers",
+                type: "scatter",
+                name: cluster.label,
+                marker: { color: color, size: 7 },
+                text: clusterArgs.map(arg => `<b>${cluster.label}</b><br>${arg.argument.replace(/(.{30})/g, "$1<br>")}`),
+                hoverinfo: "text"
+            };
+        });
+
+        Plotly.newPlot("scatterChart", scatterData, {
+            margin: { l: 20, r: 20, t: 20, b: 20 },
+            xaxis: { showticklabels: false, zeroline: false },
+            yaxis: { showticklabels: false, zeroline: false },
+            hovermode: "closest",
+            showlegend: false,
+            annotations: clusterLabels
+        }, { responsive: true });
+
+        function toggleThisGroup(headerElem) {
+            const groupElem = headerElem.parentElement;
+            const toggleElem = headerElem.querySelector(".toggle");
+            const childContainer = groupElem.querySelector(".group-children") || groupElem.querySelector(".arguments");
+            if (childContainer) {
+                if (childContainer.style.display === "none") {
+                    childContainer.style.display = "block";
+                    toggleElem.textContent = "[-]";
+                } else {
+                    childContainer.style.display = "none";
+                    toggleElem.textContent = "[+]";
+                }
+            }
+        }
+
+        function toggleAllGroups() {
+            const btn = document.getElementById("toggleAll");
+            const groups = document.querySelectorAll("#groupContainer .group");
+            const expand = btn.textContent === "すべて展開";
+            groups.forEach(group => {
+                const header = group.querySelector(".group-header");
+                const toggleElem = header.querySelector(".toggle");
+                const childContainer = group.querySelector(".group-children") || group.querySelector(".arguments");
+                if (childContainer) {
+                    childContainer.style.display = expand ? "block" : "none";
+                    toggleElem.textContent = expand ? "[-]" : "[+]";
+                }
+            });
+            btn.textContent = expand ? "すべて閉じる" : "すべて展開";
+        }
+    </script>
+</body>
+
+</html>

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -69,6 +69,12 @@ async def download_comments_csv(slug: str, api_key: str = Depends(verify_admin_a
         raise HTTPException(status_code=404, detail="CSV file not found")
     return FileResponse(path=str(csv_path), media_type="text/csv", filename=f"kouchou_{slug}.csv")
 
+@router.get("/admin/reports/{slug}/simple-html")
+def get_simple_report_html(slug: str):
+    file_path = settings.REPORT_DIR / slug / "simple_report.html"
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Simple report not found.")
+    return FileResponse(file_path, media_type="text/html")
 
 @router.get("/admin/reports/{slug}/status/step-json", dependencies=[Depends(verify_admin_api_key)])
 async def get_current_step(slug: str) -> dict:


### PR DESCRIPTION
# 変更の概要
- レポート作成時にoutpusの場所にsimple_report.htmlを作成する。
- simple_report.htmlを取得するadmin用API追加
- admin用一覧にシンブル版のリンク追加


# スクリーンショット
 ![image](https://github.com/user-attachments/assets/0a81e943-6e90-4532-9b55-d95fadfae4e1)
![image](https://github.com/user-attachments/assets/891a249b-9c02-4316-9476-e9ca443e64de)

# 変更の背景
- issue対応

# 関連Issue
https://github.com/take365/kouchou-ai/issues/9

# 動作確認の結果
レポート作成でシンプル版からのリンク押下で画面が開く。
適用前のレポートにはボタンが出るがリンク押下で失敗するがやむなし

# CLAへの同意
- [x ] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。

