### PR TITLE
Implement progress waiting screen

### DIFF
--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -83,13 +83,13 @@ export default function Page() {
         const parsed = await parseCsv(inputData.csv);
         comments = parsed.map((row, index) => {
           const rowData = row as unknown as Record<string, unknown>;
-          
+
           // コメントオブジェクトの作成（基本フィールド）
           const comment: CsvData = {
             id: row.id || `csv-${index + 1}`,
             comment: rowData[inputData.selectedCommentColumn] as string,
-            source: rowData.source as string || null,
-            url: rowData.url as string || null,
+            source: (rowData.source as string) || null,
+            url: (rowData.url as string) || null,
           };
 
           // 選択された属性カラムの値を直接追加（"attribute" プレフィックス付き）
@@ -175,7 +175,7 @@ export default function Page() {
         title: "レポート作成を開始しました",
       });
 
-      router.replace("/");
+      router.push(`/progress/${basicInfo.input}`);
     } catch (e) {
       showErrorToast(toaster, e, "レポート作成に失敗しました");
     } finally {
@@ -303,9 +303,14 @@ export default function Page() {
           <WarningSection />
 
           {/* 送信ボタン */}
-          <Button mt={10} className={"gradientBg shadow"} size={"2xl"} w={"300px"} onClick={onSubmit} loading={loading}>
-            レポート作成を開始
-          </Button>
+          <HStack mt={10} spacing={4}>
+            <Button className={"gradientBg shadow"} size={"2xl"} w={"300px"} onClick={onSubmit} loading={loading}>
+              レポート作成を開始
+            </Button>
+            <Button colorScheme="teal" size={"2xl"} w={"300px"} onClick={onSubmit} loading={loading}>
+              レポート作成(別色)
+            </Button>
+          </HStack>
         </VStack>
       </Box>
     </div>

--- a/client-admin/app/hooks/useReportProgressPoll.ts
+++ b/client-admin/app/hooks/useReportProgressPoll.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from "react";
+
+export function useReportProgressPoll(slug: string, shouldSubscribe: boolean, autoReload = true) {
+  const [progress, setProgress] = useState<string>("loading");
+  const [errorStep, setErrorStep] = useState<string | null>(null);
+  const [lastValidStep, setLastValidStep] = useState<string>("loading");
+  const [isPolling, setIsPolling] = useState<boolean>(true);
+  const [tokenUsage, setTokenUsage] = useState<number>(0);
+  const [tokenUsageInput, setTokenUsageInput] = useState<number>(0);
+  const [tokenUsageOutput, setTokenUsageOutput] = useState<number>(0);
+  const [estimatedCost, setEstimatedCost] = useState<number>(0);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+  const [pricingData, setPricingData] = useState<Record<string, Record<string, { input: number; output: number }>>>({});
+  const [isPricingLoaded, setIsPricingLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    async function fetchPricingData() {
+      try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/llm-pricing`, {
+          headers: {
+            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            Pragma: "no-cache",
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          setPricingData(data);
+        } else {
+          console.error("Failed to fetch LLM pricing data");
+          setPricingData({});
+        }
+        setIsPricingLoaded(true);
+      } catch (error) {
+        console.error("Error fetching LLM pricing data:", error);
+        setIsPricingLoaded(true);
+      }
+    }
+
+    fetchPricingData();
+  }, []);
+
+  const calculateCost = useCallback(
+    (provider: string | null, model: string | null, tokenUsageInput: number, tokenUsageOutput: number): number => {
+      if (!provider || !model || !isPricingLoaded) return 0;
+
+      const price = pricingData[provider]?.[model];
+      if (!price) return 0;
+
+      const inputCost = (tokenUsageInput / 1_000_000) * price.input;
+      const outputCost = (tokenUsageOutput / 1_000_000) * price.output;
+      return inputCost + outputCost;
+    },
+    [isPricingLoaded, pricingData],
+  );
+
+  const [hasReloaded, setHasReloaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!shouldSubscribe || !isPolling) return;
+
+    let cancelled = false;
+    let retryCount = 0;
+    const maxRetries = 10;
+
+    async function poll() {
+      if (cancelled) return;
+
+      try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports/${slug}/status/step-json`, {
+          headers: {
+            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            Pragma: "no-cache",
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+
+          if (data.token_usage !== undefined) {
+            setTokenUsage(data.token_usage);
+          }
+          if (data.token_usage_input !== undefined) {
+            setTokenUsageInput(data.token_usage_input);
+          }
+          if (data.token_usage_output !== undefined) {
+            setTokenUsageOutput(data.token_usage_output);
+          }
+          if (data.estimated_cost !== undefined) {
+            setEstimatedCost(data.estimated_cost);
+          }
+          if (data.provider !== undefined) {
+            setProvider(data.provider);
+          }
+          if (data.model !== undefined) {
+            setModel(data.model);
+          }
+
+          if (
+            (data.token_usage_input !== undefined || data.token_usage_output !== undefined) &&
+            data.provider !== undefined &&
+            data.model !== undefined
+          ) {
+            const newTokenUsageInput = data.token_usage_input !== undefined ? data.token_usage_input : tokenUsageInput;
+            const newTokenUsageOutput =
+              data.token_usage_output !== undefined ? data.token_usage_output : tokenUsageOutput;
+            const newEstimatedCost = calculateCost(data.provider, data.model, newTokenUsageInput, newTokenUsageOutput);
+            setEstimatedCost(newEstimatedCost);
+          }
+
+          if (!data.current_step || data.current_step === "loading") {
+            retryCount = 0;
+            setTimeout(poll, 3000);
+            return;
+          }
+
+          if (data.current_step === "error") {
+            setErrorStep(data.error_step || lastValidStep);
+            setProgress("error");
+            setIsPolling(false);
+            return;
+          }
+
+          setLastValidStep(data.current_step);
+          setErrorStep(null);
+          setProgress(data.current_step);
+
+          if (data.current_step === "completed") {
+            setIsPolling(false);
+            return;
+          }
+
+          setTimeout(poll, 3000);
+        } else {
+          retryCount++;
+          if (retryCount >= maxRetries) {
+            console.error("Maximum retry attempts reached");
+            setProgress("error");
+            setIsPolling(false);
+            return;
+          }
+          const retryInterval = retryCount < 3 ? 2000 : 5000;
+          setTimeout(poll, retryInterval);
+        }
+      } catch (error) {
+        console.error("Polling error:", error);
+        retryCount++;
+        if (retryCount >= maxRetries) {
+          setProgress("error");
+          setIsPolling(false);
+          return;
+        }
+        setTimeout(poll, 5000);
+      }
+    }
+
+    poll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, shouldSubscribe, lastValidStep, isPolling, tokenUsageInput, tokenUsageOutput, calculateCost]);
+
+  useEffect(() => {
+    if (autoReload && (progress === "completed" || progress === "error") && !hasReloaded) {
+      setHasReloaded(true);
+      const reloadTimeout = setTimeout(() => {
+        window.location.reload();
+      }, 1500);
+      return () => clearTimeout(reloadTimeout);
+    }
+  }, [progress, hasReloaded, autoReload]);
+
+  return { progress, errorStep, tokenUsage, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model };
+}
+
+export default useReportProgressPoll;

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import useReportProgressPoll from "./hooks/useReportProgressPoll";
 
 // ステップの定義
 const stepKeys = [
@@ -91,203 +92,6 @@ function getStatusDisplay(status: string) {
   }
 }
 
-// カスタムフック：fetchを用いて指定レポートの進捗を定期ポーリングで取得
-function useReportProgressPoll(slug: string, shouldSubscribe: boolean) {
-  const [progress, setProgress] = useState<string>("loading");
-  const [errorStep, setErrorStep] = useState<string | null>(null);
-  const [lastValidStep, setLastValidStep] = useState<string>("loading");
-  const [isPolling, setIsPolling] = useState<boolean>(true);
-  const [tokenUsage, setTokenUsage] = useState<number>(0);
-  const [tokenUsageInput, setTokenUsageInput] = useState<number>(0);
-  const [tokenUsageOutput, setTokenUsageOutput] = useState<number>(0);
-  const [estimatedCost, setEstimatedCost] = useState<number>(0);
-  const [provider, setProvider] = useState<string | null>(null);
-  const [model, setModel] = useState<string | null>(null);
-  const [pricingData, setPricingData] = useState<Record<string, Record<string, { input: number; output: number }>>>({});
-  const [isPricingLoaded, setIsPricingLoaded] = useState<boolean>(false);
-
-  // LLM価格情報を取得する
-  useEffect(() => {
-    async function fetchPricingData() {
-      try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/llm-pricing`, {
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-            "Content-Type": "application/json",
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            Pragma: "no-cache",
-          },
-        });
-
-        if (response.ok) {
-          const data = await response.json();
-          setPricingData(data);
-        } else {
-          console.error("Failed to fetch LLM pricing data");
-          // APIから取得できない場合は空のオブジェクトを設定（情報なし）
-          setPricingData({});
-        }
-        setIsPricingLoaded(true);
-      } catch (error) {
-        console.error("Error fetching LLM pricing data:", error);
-        setIsPricingLoaded(true);
-      }
-    }
-
-    fetchPricingData();
-  }, []);
-
-
-  // トークン使用量から推定コストを計算する関数
-  const calculateCost = (
-    provider: string | null,
-    model: string | null,
-    tokenUsageInput: number,
-    tokenUsageOutput: number
-  ): number => {
-    if (!provider || !model || !isPricingLoaded) return 0;
-    
-    const price = pricingData[provider]?.[model];
-    if (!price) return 0; // 不明なモデルの場合は 0 を返す
-    
-    const inputCost = (tokenUsageInput / 1_000_000) * price.input;
-    const outputCost = (tokenUsageOutput / 1_000_000) * price.output;
-    return inputCost + outputCost;
-  };
-
-  // hasReloaded のデフォルト値を false に設定
-  const [hasReloaded, setHasReloaded] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!shouldSubscribe || !isPolling) return;
-
-    let cancelled = false;
-    let retryCount = 0;
-    const maxRetries = 10;
-
-    async function poll() {
-      if (cancelled) return;
-
-      try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports/${slug}/status/step-json`, {
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-            "Content-Type": "application/json",
-            // キャッシュを防止するためのヘッダーを追加
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            Pragma: "no-cache",
-          },
-        });
-
-        if (response.ok) {
-          const data = await response.json();
-
-          if (data.token_usage !== undefined) {
-            setTokenUsage(data.token_usage);
-          }
-          if (data.token_usage_input !== undefined) {
-            setTokenUsageInput(data.token_usage_input);
-          }
-          if (data.token_usage_output !== undefined) {
-            setTokenUsageOutput(data.token_usage_output);
-          }
-          if (data.estimated_cost !== undefined) {
-            setEstimatedCost(data.estimated_cost);
-          }
-          if (data.provider !== undefined) {
-            setProvider(data.provider);
-          }
-          if (data.model !== undefined) {
-            setModel(data.model);
-          }
-          
-          // トークン使用量が更新されたら、推定コストも計算して更新
-          if (
-            (data.token_usage_input !== undefined || data.token_usage_output !== undefined) &&
-            data.provider !== undefined &&
-            data.model !== undefined
-          ) {
-            const newTokenUsageInput = data.token_usage_input !== undefined ? data.token_usage_input : tokenUsageInput;
-            const newTokenUsageOutput = data.token_usage_output !== undefined ? data.token_usage_output : tokenUsageOutput;
-            const newEstimatedCost = calculateCost(
-              data.provider,
-              data.model,
-              newTokenUsageInput,
-              newTokenUsageOutput
-            );
-            setEstimatedCost(newEstimatedCost);
-          }
-
-          if (!data.current_step || data.current_step === "loading") {
-            retryCount = 0;
-            setTimeout(poll, 3000);
-            return;
-          }
-
-          if (data.current_step === "error") {
-            setErrorStep(data.error_step || lastValidStep);
-            setProgress("error");
-            setIsPolling(false);
-            return;
-          }
-
-          setLastValidStep(data.current_step);
-          setErrorStep(null);
-          setProgress(data.current_step);
-
-          if (data.current_step === "completed") {
-            setIsPolling(false);
-            return;
-          }
-
-          // 正常なレスポンスの場合は次のポーリングをスケジュール
-          setTimeout(poll, 3000);
-        } else {
-          retryCount++;
-          if (retryCount >= maxRetries) {
-            console.error("Maximum retry attempts reached");
-            setProgress("error");
-            setIsPolling(false);
-            return;
-          }
-          const retryInterval = retryCount < 3 ? 2000 : 5000;
-          setTimeout(poll, retryInterval);
-        }
-      } catch (error) {
-        console.error("Polling error:", error);
-        retryCount++;
-        if (retryCount >= maxRetries) {
-          setProgress("error");
-          setIsPolling(false);
-          return;
-        }
-        setTimeout(poll, 5000);
-      }
-    }
-
-    poll();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [slug, shouldSubscribe, lastValidStep, isPolling]);
-
-  useEffect(() => {
-    // 完了またはエラーでかつリロード済みでない場合
-    if ((progress === "completed" || progress === "error") && !hasReloaded) {
-      setHasReloaded(true);
-
-      const reloadTimeout = setTimeout(() => {
-        window.location.reload();
-      }, 1500);
-
-      return () => clearTimeout(reloadTimeout);
-    }
-  }, [progress, hasReloaded]);
-
-  return { progress, errorStep, tokenUsage, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model };
-}
-
 // 個々のレポートカードコンポーネント
 function ReportCard({
   report,
@@ -299,10 +103,8 @@ function ReportCard({
   setReports?: (reports: Report[] | undefined) => void;
 }) {
   const statusDisplay = getStatusDisplay(report.status);
-  const { progress, errorStep, tokenUsage, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model } = useReportProgressPoll(
-    report.slug,
-    report.status !== "ready",
-  );
+  const { progress, errorStep, tokenUsage, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model } =
+    useReportProgressPoll(report.slug, report.status !== "ready");
 
   const currentStepIndex =
     progress === "completed" ? steps.length : stepKeys.indexOf(progress) === -1 ? 0 : stepKeys.indexOf(progress);
@@ -371,7 +173,19 @@ function ReportCard({
         setReports(updatedReports);
       }
     }
-  }, [progress, lastProgress, reports, setReports, report.slug, tokenUsage, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model]);
+  }, [
+    progress,
+    lastProgress,
+    reports,
+    setReports,
+    report.slug,
+    tokenUsage,
+    tokenUsageInput,
+    tokenUsageOutput,
+    estimatedCost,
+    provider,
+    model,
+  ]);
   return (
     <LinkBox
       as={Card.Root}

--- a/client-admin/app/progress/[slug]/page.tsx
+++ b/client-admin/app/progress/[slug]/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { getApiBaseUrl } from "@/app/utils/api";
+import { Header } from "@/components/Header";
+import { Box, Button, Flex, HStack, Heading, Steps, Text, VStack } from "@chakra-ui/react";
+import { useEffect } from "react";
+import useReportProgressPoll from "../../hooks/useReportProgressPoll";
+
+const stepKeys = [
+  "extraction",
+  "embedding",
+  "hierarchical_clustering",
+  "hierarchical_initial_labelling",
+  "hierarchical_merge_labelling",
+  "hierarchical_overview",
+  "hierarchical_aggregation",
+  "hierarchical_visualization",
+];
+
+const steps = [
+  { id: 1, title: "抽出" },
+  { id: 2, title: "埋め込み" },
+  { id: 3, title: "意見グループ化" },
+  { id: 4, title: "初期ラベリング" },
+  { id: 5, title: "統合ラベリング" },
+  { id: 6, title: "概要生成" },
+  { id: 7, title: "集約" },
+  { id: 8, title: "可視化" },
+];
+
+export default function Page({ params }: { params: { slug: string } }) {
+  const { slug } = params;
+  const { progress, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model } = useReportProgressPoll(
+    slug,
+    true,
+    false,
+  );
+
+  const currentStepIndex =
+    progress === "completed" ? steps.length : stepKeys.indexOf(progress) === -1 ? 0 : stepKeys.indexOf(progress);
+
+  useEffect(() => {
+    if (progress === "completed") {
+      const download = async () => {
+        try {
+          const res = await fetch(`${getApiBaseUrl()}/admin/reports/${slug}/simple-html`, {
+            headers: { "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "" },
+          });
+          if (res.ok) {
+            const blob = await res.blob();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `${slug}.html`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            window.URL.revokeObjectURL(url);
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      };
+      download();
+    }
+  }, [progress, slug]);
+
+  return (
+    <div className="container">
+      <Header />
+      <Box mx="auto" maxW="600px">
+        <Heading textAlign="center" my={10} fontSize="lg">
+          レポート生成中: {slug}
+        </Heading>
+        <Box mt={8}>
+          <Steps.Root defaultStep={currentStepIndex} count={steps.length}>
+            <Steps.List>
+              {steps.map((step, index) => {
+                const isCompleted = index < currentStepIndex;
+                const stepColor = isCompleted ? "green.500" : "gray.300";
+                return (
+                  <Steps.Item key={step.id} index={index} title={step.title}>
+                    <Flex direction="column" align="center">
+                      <Steps.Indicator boxSize="24px" bg={stepColor} position="relative" />
+                      <Steps.Title mt={1} fontSize="sm" whiteSpace="nowrap" textAlign="center" color={stepColor}>
+                        {step.title}
+                      </Steps.Title>
+                    </Flex>
+                    <Steps.Separator borderColor={stepColor} />
+                  </Steps.Item>
+                );
+              })}
+            </Steps.List>
+          </Steps.Root>
+        </Box>
+        <VStack mt={6} spacing={2} align="start">
+          <Text fontSize="sm">入力トークン: {tokenUsageInput.toLocaleString()}</Text>
+          <Text fontSize="sm">出力トークン: {tokenUsageOutput.toLocaleString()}</Text>
+          <Text fontSize="sm">推定コスト: {estimatedCost ? `$${estimatedCost.toFixed(6)}` : "-"}</Text>
+          {provider && model && (
+            <Text fontSize="sm">
+              モデル: {provider}/{model}
+            </Text>
+          )}
+        </VStack>
+        {progress === "completed" && (
+          <HStack justify="center" mt={10}>
+            <Button onClick={() => window.open(`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${slug}`, "_blank")}>
+              レポートを開く
+            </Button>
+          </HStack>
+        )}
+        {progress === "error" && (
+          <Text color="red.600" mt={4}>
+            エラーが発生しました。再度お試しください。
+          </Text>
+        )}
+        <Text mt={10} fontSize="xs" color="gray.500">
+          生成されたレポートの内容は必ずご自身で確認してください。
+        </Text>
+      </Box>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
作成ページに代替送信ボタンを追加
作成後に進捗ページにリダイレクトする
useReportProgressPollフックを抽出する。
ステータスをポーリングして自動ダウンロードする新しい進捗ページを追加する

## Summary
- add alternate submit button on create page
- redirect to progress page after creating
- extract useReportProgressPoll hook
- add new progress page that polls status and auto-downloads

## Testing
- `npm test --silent --prefix client-admin`
- `pytest -q server/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6845f64e83088332b642746822aa619f