### PR TITLE
Add JSON download endpoint

### DIFF
--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -69,6 +69,14 @@ async def download_comments_csv(slug: str, api_key: str = Depends(verify_admin_a
         raise HTTPException(status_code=404, detail="CSV file not found")
     return FileResponse(path=str(csv_path), media_type="text/csv", filename=f"kouchou_{slug}.csv")
 
+
+@router.get("/admin/comments/{slug}/json")
+async def download_comments_json(slug: str, api_key: str = Depends(verify_admin_api_key)) -> FileResponse:
+    json_path = settings.REPORT_DIR / slug / "hierarchical_result.json"
+    if not json_path.exists():
+        raise HTTPException(status_code=404, detail="JSON file not found")
+    return FileResponse(path=str(json_path), media_type="application/json", filename=f"kouchou_{slug}.json")
+
 @router.get("/admin/reports/{slug}/simple-html")
 def get_simple_report_html(slug: str):
     file_path = settings.REPORT_DIR / slug / "simple_report.html"


### PR DESCRIPTION
## Summary
- enable JSON download of hierarchical results

## Testing
- `pytest -q` *(fails: pyenv Python 3.12.8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68470721d0a08332944be9cf0567c1ee