### PR TITLE
前回の抽出で行が分離したCSVを再利用すると抽出スキップでエラーになるバグ対応[#20]

### DIFF
--- a/server/broadlistening/pipeline/steps/extraction.py
+++ b/server/broadlistening/pipeline/steps/extraction.py
@@ -57,10 +57,9 @@ def extraction(config):
 
     if skip_extraction:
         print("⏩ 抽出ステップをスキップします（skip_extraction が有効）")
-        for _, comment_id in enumerate(comment_ids):
-            comment_body = comments.loc[comment_id]["comment-body"]
+        for comment_id, comment_body in comments["comment-body"].items():
             arg_id = f"A{comment_id}_0"
-            argument_map[comment_body] = {
+            argument_map[arg_id] = {
                 "arg-id": arg_id,
                 "argument": comment_body,
             }


### PR DESCRIPTION

## 要約
- skip_extraction が true の場合、コメント ID が重複する CSV を処理する。
- インデックスをリセットせずにコメント本文を直接反復処理する

###
https://github.com/take365/kouchou-ai/issues/20
