### PR TITLE
【追補】.env.example および bat ファイルの対応方針反映漏れを修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ OPENAI_API_KEY=
 # OpenRouterのAPIキー。OpenRouterアカウント上でAPIキーを発行して記載。
 OPENROUTER_API_KEY=
 # ワンタイム利用のAPIキー入力を有効にするかどうか
-ONETIME_LLM_API_KEY_MODE=false
+NEXT_PUBLIC_ONETIME_LLM_API_KEY_MODE=false
 # clientからAPIにアクセスする際のAPIキー。サーバー側でセットされる。NEXT_PUBLIC_PUBLIC_API_KEYと同じ値を設定。
 PUBLIC_API_KEY=public
 # client-adminからAPIにアクセスする際のAPIキー。サーバー側でセットされる。NEXT_PUBLIC_ADMIN_API_KEYと同じ値を設定。

--- a/experimental/direct_win/direct_start_win.bat
+++ b/experimental/direct_win/direct_start_win.bat
@@ -67,6 +67,8 @@ for /f "usebackq tokens=1,* delims==" %%A in (".env") do (
             echo !KEY!=!VALUE!>>%ADMIN_ENV%
         ) else if /i "!KEY!"=="BASIC_AUTH_PASSWORD" (
             echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_ONETIME_LLM_API_KEY_MODE" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
         ) else if /i "!KEY!"=="NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID" (
             echo !KEY!=!VALUE!>>%ADMIN_ENV%
         )


### PR DESCRIPTION
# 変更の概要
- `otmfo6-codex/対応方針の検討` に含まれるべき `.env.example` および `direct_start_win.bat` の修正が漏れていたため、追加対応として本PRで反映します。
