### PR TITLE
Implement error info return #12

### DIFF
--- a/client-admin/app/hooks/useReportProgressPoll.ts
+++ b/client-admin/app/hooks/useReportProgressPoll.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 export function useReportProgressPoll(slug: string, shouldSubscribe: boolean, autoReload = true) {
   const [progress, setProgress] = useState<string>("loading");
   const [errorStep, setErrorStep] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorStackTrace, setErrorStackTrace] = useState<string | null>(null);
   const [lastValidStep, setLastValidStep] = useState<string>("loading");
   const [isPolling, setIsPolling] = useState<boolean>(true);
   const [tokenUsage, setTokenUsage] = useState<number>(0);
@@ -121,6 +123,8 @@ export function useReportProgressPoll(slug: string, shouldSubscribe: boolean, au
 
           if (data.current_step === "error") {
             setErrorStep(data.error_step || lastValidStep);
+            setErrorMessage(data.error_message || null);
+            setErrorStackTrace(data.error_stack_trace || null);
             setProgress("error");
             setIsPolling(false);
             return;
@@ -128,6 +132,8 @@ export function useReportProgressPoll(slug: string, shouldSubscribe: boolean, au
 
           setLastValidStep(data.current_step);
           setErrorStep(null);
+          setErrorMessage(null);
+          setErrorStackTrace(null);
           setProgress(data.current_step);
 
           if (data.current_step === "completed") {
@@ -176,7 +182,18 @@ export function useReportProgressPoll(slug: string, shouldSubscribe: boolean, au
     }
   }, [progress, hasReloaded, autoReload]);
 
-  return { progress, errorStep, tokenUsage, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model };
+  return {
+    progress,
+    errorStep,
+    errorMessage,
+    errorStackTrace,
+    tokenUsage,
+    tokenUsageInput,
+    tokenUsageOutput,
+    estimatedCost,
+    provider,
+    model,
+  };
 }
 
 export default useReportProgressPoll;

--- a/client-admin/app/progress/[slug]/page.tsx
+++ b/client-admin/app/progress/[slug]/page.tsx
@@ -41,7 +41,16 @@ export default function Page() {
   const shouldDownloadCsv = searchParams.get("csv") !== "false";
   const shouldDownloadJson = searchParams.get("json") === "true";
 
-  const { progress, tokenUsageInput, tokenUsageOutput, estimatedCost, provider, model } = useReportProgressPoll(
+  const {
+    progress,
+    errorMessage,
+    errorStackTrace,
+    tokenUsageInput,
+    tokenUsageOutput,
+    estimatedCost,
+    provider,
+    model,
+  } = useReportProgressPoll(
     slug,
     true,
     false,
@@ -171,9 +180,19 @@ export default function Page() {
           </HStack>
         )}
         {progress === "error" && (
-          <Text color="red.600" mt={4}>
-            エラーが発生しました。再度お試しください。
-          </Text>
+          <Box mt={4} color="red.600">
+            <Text fontWeight="bold">エラーが発生しました</Text>
+            {errorMessage && (
+              <Text whiteSpace="pre-wrap" fontSize="sm" mt={2}>
+                {errorMessage}
+              </Text>
+            )}
+            {errorStackTrace && (
+              <Box as="pre" whiteSpace="pre-wrap" fontSize="xs" mt={2} overflowX="auto">
+                {errorStackTrace}
+              </Box>
+            )}
+          </Box>
         )}
         <Text mt={10} fontSize="xs" color="gray.500">
           生成されたレポートの内容は必ずご自身で確認してください。

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -108,6 +108,8 @@ async def get_current_step(slug: str) -> dict:
         # error キーが存在する場合はエラーとみなす
         if "error" in status:
             response["current_step"] = "error"
+            response["error_message"] = status.get("error")
+            response["error_stack_trace"] = status.get("error_stack_trace")
             return response
 
         # 全体のステータスが "completed" なら、current_step も "completed" とする


### PR DESCRIPTION
## Summary
- APIにおけるパイプラインのエラー処理を改善
- エラーメッセージとスタックトレースを進捗ページに伝達
- レポート生成に失敗した場合に、詳細なエラー情報を表示する。

https://github.com/take365/kouchou-ai/issues/12

------
https://chatgpt.com/codex/tasks/task_e_684a459266408332b7dcf5519153eb15