### PR TITLE
Add upload fallback for client report #15

### DIFF
--- a/client/app/[slug]/page.tsx
+++ b/client/app/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Header } from "@/components/Header";
 import { Analysis } from "@/components/report/Analysis";
 import { BackButton } from "@/components/report/BackButton";
 import { ClientContainer } from "@/components/report/ClientContainer";
+import { FileUploadFallback } from "@/components/report/FileUploadFallback";
 import { Overview } from "@/components/report/Overview";
 import { Reporter } from "@/components/reporter/Reporter";
 import type { Meta, Report, Result } from "@/type";
@@ -110,7 +111,10 @@ export default async function Page({ params }: PageProps) {
     notFound();
   }
 
-  const meta: Meta = await metaResponse.json();
+  const meta: Meta | undefined = metaResponse.ok ? await metaResponse.json() : undefined;
+  if (!resultResponse.ok) {
+    return <FileUploadFallback meta={meta} />;
+  }
   const result: Result = await resultResponse.json();
 
   return (
@@ -122,11 +126,13 @@ export default async function Page({ params }: PageProps) {
         <Analysis result={result} />
         <BackButton />
         <Separator my={12} maxW={"750px"} mx={"auto"} />
-        <Box maxW={"750px"} mx={"auto"} mb={24}>
-          <Reporter meta={meta} />
-        </Box>
+        {meta && (
+          <Box maxW={"750px"} mx={"auto"} mb={24}>
+            <Reporter meta={meta} />
+          </Box>
+        )}
       </div>
-      <Footer meta={meta} />
+      {meta && <Footer meta={meta} />}
     </>
   );
 }

--- a/client/components/report/FileUploadFallback.tsx
+++ b/client/components/report/FileUploadFallback.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Footer } from "@/components/Footer";
+import { Header } from "@/components/Header";
+import { Analysis } from "@/components/report/Analysis";
+import { BackButton } from "@/components/report/BackButton";
+import { ClientContainer } from "@/components/report/ClientContainer";
+import { Overview } from "@/components/report/Overview";
+import { Reporter } from "@/components/reporter/Reporter";
+import { FileUploadDropzone, FileUploadList, FileUploadRoot } from "@/components/ui/file-upload";
+import type { Meta, Result } from "@/type";
+import { Box, Text } from "@chakra-ui/react";
+import { useState } from "react";
+
+interface Props {
+  meta?: Meta;
+}
+
+export function FileUploadFallback({ meta }: Props) {
+  const [result, setResult] = useState<Result | null>(null);
+  const handleChange = async (e: { acceptedFiles: File[] }) => {
+    const file = e.acceptedFiles[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text) as Result;
+      setResult(data);
+    } catch (err) {
+      console.error("Invalid JSON", err);
+    }
+  };
+
+  if (result) {
+    return (
+      <>
+        <div className="container">
+          <Header />
+          <Overview result={result} />
+          <ClientContainer result={result} />
+          <Analysis result={result} />
+          <BackButton />
+          {meta && (
+            <Box maxW="750px" mx="auto" mb={24}>
+              <Reporter meta={meta} />
+            </Box>
+          )}
+        </div>
+        {meta && <Footer meta={meta} />}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="container">
+        <Header />
+        <Box maxW="750px" mx="auto" my={24}>
+          <Text mb={4}>hierarchical_result.jsonをアップロードしてください</Text>
+          <FileUploadRoot
+            w="full"
+            alignItems="stretch"
+            accept={["application/json"]}
+            inputProps={{ multiple: false }}
+            onFileChange={handleChange}
+          >
+            <Box>
+              <FileUploadDropzone label="JSON file" description=".json" />
+            </Box>
+            <FileUploadList clearable showSize />
+          </FileUploadRoot>
+        </Box>
+      </div>
+      {meta && <Footer meta={meta} />}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
ユーザはhierarchical_result.jsonをアップロードする。
レポート取得失敗時に[slug]ページのコンポーネントを呼び出す
404チェックロジックを修正

https://github.com/take365/kouchou-ai/issues/15
------
https://chatgpt.com/codex/tasks/task_e_684a50c7e4b8833289736eaa47349dea