### PR TITLE
Implement issue 26 server features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ CLIENT_STATIC_BUILD_BASEPATH=http://client-static-build:3200
 
 # clientおよびclient-adminでセットが必要な環境変数
 # next.jsのクライアントサイドからpython APIにアクセスする際のパス。変更不要
-NEXT_PUBLIC_API_BASEPATH=http://localhost:8000
+NEXT_PUBLIC_API_BASEPATH=http://localhost:8000,http://localhost:8001
 # next.jsのサーバーサイドからpython APIにアクセスする際のパス。変更不要
 API_BASEPATH=http://api:8000
 # clientのサイトURL

--- a/client-admin/app/utils/api.ts
+++ b/client-admin/app/utils/api.ts
@@ -1,10 +1,12 @@
-export const getApiBaseUrl = () => {
-  if (typeof window !== "undefined") {
-    return process.env.NEXT_PUBLIC_API_BASEPATH;
-  }
-  // undefinedでなければAPI_BASEPATHを返す
-  if (process.env.API_BASEPATH) {
-    return process.env.API_BASEPATH;
-  }
-  return process.env.NEXT_PUBLIC_API_BASEPATH;
+export const getApiBaseUrls = (): string[] => {
+  const base =
+    typeof window !== "undefined"
+      ? process.env.NEXT_PUBLIC_API_BASEPATH
+      : process.env.API_BASEPATH || process.env.NEXT_PUBLIC_API_BASEPATH;
+  return base ? base.split(",").map((s) => s.trim()).filter(Boolean) : [];
+};
+
+export const getApiBaseUrl = (): string => {
+  const urls = getApiBaseUrls();
+  return urls[0] || "";
 };

--- a/client/.env-sample
+++ b/client/.env-sample
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_API_BASEPATH="http://localhost:8000"
+NEXT_PUBLIC_API_BASEPATH="http://localhost:8000,http://localhost:8001"
 NEXT_PUBLIC_PUBLIC_API_KEY="xxxxxxxxxx"
 NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 NEXT_PUBLIC_GA_MEASUREMENT_ID=""

--- a/client/app/utils/api.ts
+++ b/client/app/utils/api.ts
@@ -6,17 +6,15 @@
  *
  * @returns APIのベースURL
  */
+export const getApiBaseUrls = (): string[] => {
+  const base =
+    typeof window !== "undefined"
+      ? process.env.NEXT_PUBLIC_API_BASEPATH
+      : process.env.API_BASEPATH || process.env.NEXT_PUBLIC_API_BASEPATH;
+  return base ? base.split(",").map((s) => s.trim()).filter(Boolean) : [];
+};
+
 export const getApiBaseUrl = (): string => {
-  // クライアントサイド（ブラウザ環境）の場合
-  if (typeof window !== "undefined") {
-    return process.env.NEXT_PUBLIC_API_BASEPATH || "";
-  }
-
-  // サーバーサイドでAPI_BASEPATHが設定されている場合
-  if (process.env.API_BASEPATH) {
-    return process.env.API_BASEPATH;
-  }
-
-  // それ以外の場合はNEXT_PUBLIC_API_BASEPATHを使用
-  return process.env.NEXT_PUBLIC_API_BASEPATH || "";
+  const urls = getApiBaseUrls();
+  return urls[0] || "";
 };

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -18,8 +18,13 @@ from src.services.llm_models import get_models_by_provider
 from src.services.llm_pricing import LLMPricing
 from src.services.report_launcher import execute_aggregation, launch_report_generation
 from src.services.report_status import (
+    count_processing_jobs,
+    count_reservations,
+    create_reservation,
+    generate_session_token,
     invalidate_report_cache,
     load_status_as_reports,
+    release_reservation,
     set_status,
     update_report_config,
     update_report_visibility_state,
@@ -43,12 +48,36 @@ async def get_reports(api_key: str = Depends(verify_admin_api_key)) -> list[Repo
     return load_status_as_reports()
 
 
+@router.get("/admin/server/status")
+async def server_status(api_key: str = Depends(verify_admin_api_key)) -> dict:
+    return {
+        "processing_jobs": count_processing_jobs(),
+        "reservations": count_reservations(),
+    }
+
+
+@router.post("/admin/server/reserve")
+async def reserve_server(api_key: str = Depends(verify_admin_api_key)) -> dict:
+    token = create_reservation()
+    return {"reservation_token": token}
+
+
+@router.post("/admin/server/release")
+async def release_server(
+    token: str = Query(...),
+    api_key: str = Depends(verify_admin_api_key),
+) -> dict:
+    release_reservation(token)
+    return {"released": True}
+
+
 @router.post("/admin/reports", status_code=202)
 async def create_report(report: ReportInput, api_key: str = Depends(verify_admin_api_key)) -> ORJSONResponse:
     try:
         launch_report_generation(report)
+        token = generate_session_token(report.input)
         return ORJSONResponse(
-            content=None,
+            content={"token": token},
             headers={
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",

--- a/server/src/routers/report.py
+++ b/server/src/routers/report.py
@@ -6,7 +6,7 @@ from fastapi.security.api_key import APIKeyHeader
 
 from src.config import settings
 from src.schemas.report import Report, ReportStatus, ReportVisibility
-from src.services.report_status import load_status_as_reports
+from src.services.report_status import load_status_as_reports, validate_session_token
 
 logger = logging.getLogger("uvicorn")
 
@@ -15,13 +15,13 @@ router = APIRouter()
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
 
-async def verify_public_api_key(api_key: str = Security(api_key_header)):
-    if not api_key or api_key != settings.PUBLIC_API_KEY:
-        raise HTTPException(status_code=401, detail="Invalid API key")
+async def verify_session_token(api_key: str = Security(api_key_header)):
+    if not api_key or not validate_session_token(api_key):
+        raise HTTPException(status_code=401, detail="Invalid token")
     return api_key
 
 
-@router.get("/reports", dependencies=[Depends(verify_public_api_key)])
+@router.get("/reports", dependencies=[Depends(verify_session_token)])
 async def reports() -> list[Report]:
     all_reports = load_status_as_reports()
     ready_reports = [
@@ -31,7 +31,7 @@ async def reports() -> list[Report]:
 
 
 @router.get("/reports/{slug}")
-async def report(slug: str, api_key: str = Depends(verify_public_api_key)) -> dict:
+async def report(slug: str, api_key: str = Depends(verify_session_token)) -> dict:
     report_path = settings.REPORT_DIR / slug / "hierarchical_result.json"
     all_reports = load_status_as_reports()
     target_report_status = next((report for report in all_reports if report.slug == slug), None)

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -8,7 +8,12 @@ import pandas as pd
 
 from src.config import settings
 from src.schemas.admin_report import ReportInput
-from src.services.report_status import add_new_report_to_status, set_status, update_token_usage
+from src.services.report_status import (
+    add_new_report_to_status,
+    invalidate_session_token,
+    set_status,
+    update_token_usage,
+)
 from src.services.report_sync import ReportSyncService
 from src.utils.logger import setup_logger
 
@@ -149,6 +154,7 @@ def _monitor_process(process: subprocess.Popen, slug: str) -> None:
             logger.error(f"Error updating token usage for {slug}: {e}")
 
         set_status(slug, "ready")
+        invalidate_session_token(slug)
 
         logger.info(f"Syncing files for {slug} to storage")
         report_sync_service = ReportSyncService()
@@ -163,6 +169,7 @@ def _monitor_process(process: subprocess.Popen, slug: str) -> None:
 
     else:
         set_status(slug, "error")
+        invalidate_session_token(slug)
 
 
 def launch_report_generation(report_input: ReportInput) -> None:

--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -1,7 +1,8 @@
 import json
 import logging
+import secrets
 import threading
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import requests
 
@@ -17,6 +18,7 @@ logger = logging.getLogger("uvicorn")
 STATE_FILE = settings.DATA_DIR / "report_status.json"
 _lock = threading.RLock()
 _report_status = {}
+_reservations: dict[str, str] = {}
 
 
 # FIXME: report_status.jsonのフォーマット変更に対応するためのコード。広聴AIをver3.0にした段階で削除する。
@@ -233,3 +235,62 @@ def update_report_config(slug: str, updated_config: ReportConfigUpdate) -> dict:
 
     invalidate_report_cache(slug)
     return _report_status[slug]
+
+
+def generate_session_token(slug: str, ttl_hours: int = 24) -> str:
+    token = secrets.token_urlsafe(16)
+    expiry = datetime.now(UTC) + timedelta(hours=ttl_hours)
+    with _lock:
+        if slug not in _report_status:
+            raise ValueError(f"slug {slug} not found in report status")
+        _report_status[slug]["session_token"] = token
+        _report_status[slug]["session_expiry"] = expiry.isoformat()
+        save_status()
+    return token
+
+
+def validate_session_token(token: str) -> bool:
+    with _lock:
+        for status in _report_status.values():
+            if status.get("session_token") == token:
+                expiry_str = status.get("session_expiry")
+                if expiry_str:
+                    try:
+                        expiry = datetime.fromisoformat(expiry_str)
+                        if expiry > datetime.now(UTC):
+                            return True
+                    except ValueError:
+                        return False
+        return False
+
+
+def invalidate_session_token(slug: str) -> None:
+    with _lock:
+        if slug in _report_status:
+            _report_status[slug].pop("session_token", None)
+            _report_status[slug].pop("session_expiry", None)
+            save_status()
+
+
+def count_processing_jobs() -> int:
+    with _lock:
+        return sum(
+            1
+            for r in _report_status.values()
+            if r.get("status") == ReportStatus.PROCESSING.value
+        )
+
+
+def create_reservation() -> str:
+    token = secrets.token_urlsafe(8)
+    _reservations[token] = "reserved"
+    return token
+
+
+def release_reservation(token: str) -> None:
+    _reservations.pop(token, None)
+
+
+def count_reservations() -> int:
+    return len(_reservations)
+


### PR DESCRIPTION
## Summary
セッション・トークンの管理を追加する
セッション・トークンを使用するようにレポート・ルートを更新する
管理レポート作成時にトークンを返す
サーバ・ステータスと予約 API を公開する
レポート生成後にトークンを無効にする
クライアントで複数の API ベース URL をサポートする
環境ファイルで複数の API サーバ URL を文書化する
## Testing
- `ruff check server/src`
- `npm run lint` *(fails: biome not found)*
- `make lint/api-check` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7bc084388332be8087ed2a380383