### PR TITLE
Add warning for large inputs

### DIFF
--- a/client-admin/app/create/components/WarningSection.tsx
+++ b/client-admin/app/create/components/WarningSection.tsx
@@ -29,7 +29,9 @@ export function WarningSection({ commentCount, useRandomSample, setUseRandomSamp
           <Alert.Title>入力データが {commentCount} 件あります。1000件を超える場合、処理が失敗する可能性があります。</Alert.Title>
           <RadioCardRoot
             value={useRandomSample ? "sample" : "all"}
-            onValueChange={(val) => setUseRandomSample(val === "sample")}
+            onValueChange={(details) =>
+              setUseRandomSample(details.value === "sample")
+            }
           >
             <RadioCardLabel>処理方法を選択</RadioCardLabel>
             <RadioCardItem value="sample" label="ランダムに1000件を抜粋して処理" />

--- a/client-admin/app/create/components/WarningSection.tsx
+++ b/client-admin/app/create/components/WarningSection.tsx
@@ -1,9 +1,20 @@
 import { Alert, Stack } from "@chakra-ui/react";
+import {
+  RadioCardRoot,
+  RadioCardItem,
+  RadioCardLabel,
+} from "@/components/ui/radio-card";
+
+interface Props {
+  commentCount: number;
+  useRandomSample: boolean;
+  setUseRandomSample: (v: boolean) => void;
+}
 
 /**
  * 警告メッセージセクションコンポーネント
  */
-export function WarningSection() {
+export function WarningSection({ commentCount, useRandomSample, setUseRandomSample }: Props) {
   return (
     <Stack gap="4" width="full">
       <Alert.Root status="warning">
@@ -12,6 +23,20 @@ export function WarningSection() {
           レポートの作成には数分かかる可能性があります。試験環境のため５分を超える処理は失敗する可能性があります。失敗する場合は処理のスキップや、データ量の調整などを試みてください
         </Alert.Title>
       </Alert.Root>
+      {commentCount > 1000 && (
+        <Alert.Root status="warning">
+          <Alert.Indicator />
+          <Alert.Title>入力データが {commentCount} 件あります。1000件を超える場合、処理が失敗する可能性があります。</Alert.Title>
+          <RadioCardRoot
+            value={useRandomSample ? "sample" : "all"}
+            onValueChange={(val) => setUseRandomSample(val === "sample")}
+          >
+            <RadioCardLabel>処理方法を選択</RadioCardLabel>
+            <RadioCardItem value="sample" label="ランダムに1000件を抜粋して処理" />
+            <RadioCardItem value="all" label="リスクを承知して実施" />
+          </RadioCardRoot>
+        </Alert.Root>
+      )}
     </Stack>
   );
 }

--- a/client-admin/app/create/hooks/useInputData.ts
+++ b/client-admin/app/create/hooks/useInputData.ts
@@ -28,6 +28,10 @@ export function useInputData(onDataLoaded: (commentCount: number) => void) {
   const [selectedCommentColumn, setSelectedCommentColumn] = useState<string>("");
   const [selectedAttributeColumns, setSelectedAttributeColumns] = useState<string[]>([]);
 
+  // 追加: コメント件数とサンプリング設定
+  const [commentCount, setCommentCount] = useState<number>(0);
+  const [useRandomSample, setUseRandomSample] = useState<boolean>(false);
+
   /**
    * 最適なカラムを選択する関数
    */
@@ -43,6 +47,8 @@ export function useInputData(onDataLoaded: (commentCount: number) => void) {
         setSelectedCommentColumn(bestColumn);
       }
 
+      setCommentCount(data.length);
+      setUseRandomSample(data.length > 1000);
       onDataLoaded(data.length);
     },
     [onDataLoaded],
@@ -67,6 +73,8 @@ export function useInputData(onDataLoaded: (commentCount: number) => void) {
         setCsvColumns([]);
         setSelectedCommentColumn("");
         setSelectedAttributeColumns([]);
+        setCommentCount(0);
+        setUseRandomSample(false);
       }
     },
     [selectBestColumn],
@@ -142,6 +150,8 @@ export function useInputData(onDataLoaded: (commentCount: number) => void) {
       setSelectedCommentColumn("");
       setSelectedAttributeColumns([]);
       setCsvColumns([]);
+      setCommentCount(0);
+      setUseRandomSample(false);
     }
   }, [importedId]);
 
@@ -167,6 +177,8 @@ export function useInputData(onDataLoaded: (commentCount: number) => void) {
         setCsvColumns([]);
         setSelectedCommentColumn("");
         setSelectedAttributeColumns([]);
+        setCommentCount(0);
+        setUseRandomSample(false);
       }
     },
     [csv, spreadsheetData, selectBestColumn],
@@ -189,6 +201,9 @@ export function useInputData(onDataLoaded: (commentCount: number) => void) {
     selectedCommentColumn,
     selectedAttributeColumns,
     canImport,
+    commentCount,
+    useRandomSample,
+    setUseRandomSample,
     setInputType: handleInputTypeChange,
     setCsv: handleCsvChange,
     setSpreadsheetUrl,

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -31,6 +31,7 @@ import { useInputData } from "./hooks/useInputData";
 import { usePromptSettings } from "./hooks/usePromptSettings";
 import { type CsvData, parseCsv } from "./parseCsv";
 import { showErrorToast } from "./utils/error-handler";
+import { sampleWithSeed } from "./utils/sample";
 import { generateDefaultQuestionTitle } from "./utils/generateTitle";
 import { validateFormValues } from "./utils/validation";
 
@@ -170,8 +171,12 @@ export default function Page() {
             }
           }
 
-          return comment;
-        });
+        return comment;
+      });
+      }
+
+      if (inputData.useRandomSample && comments.length > 1000) {
+        comments = sampleWithSeed(comments, 1000);
       }
     } catch (e) {
       toaster.create({
@@ -396,7 +401,11 @@ export default function Page() {
             />
           </Presence>
           {/* 警告メッセージ */}
-          <WarningSection />
+          <WarningSection
+            commentCount={inputData.commentCount}
+            useRandomSample={inputData.useRandomSample}
+            setUseRandomSample={inputData.setUseRandomSample}
+          />
           {process.env.NEXT_PUBLIC_ENVIRONMENT !== "instant" && (
             <Button className="gradientBg shadow" size="2xl" w="300px" onClick={onSubmitAndReturn} loading={loading}>
               レポート作成を開始

--- a/client-admin/app/create/utils/sample.ts
+++ b/client-admin/app/create/utils/sample.ts
@@ -1,0 +1,13 @@
+export function sampleWithSeed<T>(array: T[], n: number, seed = 42): T[] {
+  let result = array.slice();
+  let s = seed;
+  function random() {
+    s = (s * 9301 + 49297) % 233280;
+    return s / 233280;
+  }
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result.slice(0, n);
+}


### PR DESCRIPTION
## Summary
- 読み込まれたコメントが1000を超えると警告する
- ランダムサンプリングか全データを使用するかをユーザーに選択させる
- 固定シードによる決定論的サンプリングを実装する

### 関連
https://github.com/take365/kouchou-ai/issues/34

## Testing
- `npm run lint` *(fails: biome not found)*
- `make lint/api-check` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d27f89b08332b5d3b3db6dbc392e